### PR TITLE
Add ability to specify interval-update value in vas.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,14 @@ upm-computerou-attr option in vas.conf. Changed to 'department' to work in a mul
 
 - *Default*: 'department'
 
+vas_conf_vasd_update_interval
+-----------------------------
+Integer for number of seconds to set update-interval in [vasd] section of vas.conf. See VAS.CONF(5) for more info.
+
+
+- *Default*: 600
+
+
 vas_config_path
 ---------------
 Path to VAS config file.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,6 +22,7 @@ class vas (
   $vas_conf_preload_nested_memberships = 'UNSET',
   $vas_conf_update_process             = '/opt/quest/libexec/vas/mapupdate_2307',
   $vas_conf_upm_computerou_attr        = 'department',
+  $vas_conf_vasd_update_interval       = '600',
   $vas_config_path                     = '/etc/opt/quest/vas/vas.conf',
   $vas_config_owner                    = 'root',
   $vas_config_group                    = 'root',
@@ -41,6 +42,9 @@ class vas (
   $solaris_adminpath                   = 'UNSET',
   $solaris_responsepattern             = 'UNSET',
 ) {
+
+  # validate params
+  validate_re($vas_conf_vasd_update_interval, '^\d+$', "vas::vas_conf_vasd_update_interval must be an integer. Detected value is <${vas_conf_vasd_update_interval}>.")
 
   case $::kernel {
     'Linux': {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -123,6 +123,7 @@ describe 'vas' do
  update-process = /opt/quest/libexec/vas/mapupdate_2307
 
 [vasd]
+ update-interval = 600
  upm-search-path = ou=users,dc=example,dc=com
  workstation-mode = false
  auto-ticket-renew-interval = 32400
@@ -221,6 +222,7 @@ describe 'vas' do
  update-process = /opt/quest/libexec/vas/mapupdate_2307
 
 [vasd]
+ update-interval = 600
  upm-search-path = ou=site,ou=users,dc=example,dc=com
  workstation-mode = false
  auto-ticket-renew-interval = 32400
@@ -292,6 +294,7 @@ describe 'vas' do
  update-process = /opt/quest/libexec/vas/mapupdate_2307
 
 [vasd]
+ update-interval = 600
  upm-search-path = ou=users,dc=example,dc=com
  workstation-mode = false
  auto-ticket-renew-interval = 32400
@@ -441,6 +444,53 @@ describe 'vas' do
           'mode'    => '0644',
         })
         should contain_file('vas_config').with_content(/ preload-nested-memberships = false/)
+      end
+    end
+
+    context 'with vas_conf_vasd_update_interval specified' do
+      let :facts do
+        {
+          :kernel            => 'Linux',
+          :osfamily          => 'RedHat',
+          :lsbmajdistrelease => '6',
+          :fqdn              => 'host.example.com',
+          :domain            => 'example.com',
+        }
+      end
+      let :params do
+        { :vas_conf_vasd_update_interval => '1200' }
+      end
+
+      it do
+        should contain_file('vas_config').with({
+          'ensure'  => 'present',
+          'path'    => '/etc/opt/quest/vas/vas.conf',
+          'owner'   => 'root',
+          'group'   => 'root',
+          'mode'    => '0644',
+        })
+      end
+      it { should contain_file('vas_config').with_content(/ update-interval = 1200/) }
+    end
+
+    context 'with vas_conf_vasd_update_interval set to invalid string (non-integer)' do
+      let :facts do
+        {
+          :kernel            => 'Linux',
+          :osfamily          => 'RedHat',
+          :lsbmajdistrelease => '6',
+          :fqdn              => 'host.example.com',
+          :domain            => 'example.com',
+        }
+      end
+      let :params do
+        { :vas_conf_vasd_update_interval => '600invalid' }
+      end
+
+      it 'should fail' do
+        expect {
+          should include_class('vas')
+        }.to raise_error(Puppet::Error,/vas::vas_conf_vasd_update_interval must be an integer. Detected value is <600invalid>./)
       end
     end
 

--- a/templates/vas.conf.erb
+++ b/templates/vas.conf.erb
@@ -38,6 +38,7 @@
 <% end -%>
 
 [vasd]
+ update-interval = <%= @vas_conf_vasd_update_interval %>
  upm-search-path = <%= users_ou %>
 <% if @virtual == "zone" -%>
  timesync-interval = 0


### PR DESCRIPTION
This patch lets you specify the interval-update in the [vasd] section of
the vas.conf. The default is 600 (10 minutes) which is taken from the
man page.
