### PR TITLE
Add option to create symlink to vastool binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,3 +337,21 @@ solaris_adminpath
 solaris_responsepattern
 -----------------------
 - *Default*: 'UNSET'
+
+vastool_binary
+-------------
+Path to vastool binary to create symlink from
+
+- *Default*: '/opt/quest/bin/vastool'
+
+symlink_vastool_binary_target
+----------------------------
+Path to where the symlink should be created
+
+- *Default*: '/usr/bin/vastool'
+
+symlink_vastool_binary
+---------------------
+Boolean for ensuring a symlink for vastool_binary to symlink_vastool_binary_target. This is useful since /opt/quest/bin is a non-standard location that is not in your $PATH.
+
+- *Default*: false

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -53,6 +53,9 @@ class vas (
   $solaris_vasgppath                                    = 'UNSET',
   $solaris_adminpath                                    = 'UNSET',
   $solaris_responsepattern                              = 'UNSET',
+  $vastool_binary                                       = '/opt/quest/bin/vastool',
+  $symlink_vastool_binary_target                        = '/usr/bin/vastool',
+  $symlink_vastool_binary                               = false,
 ) {
 
   # validate params
@@ -199,5 +202,25 @@ class vas (
     timeout => 1800,
     creates => $once_file,
     require => [Package['vasclnt','vasyp','vasgp'],File['keytab']],
+  }
+
+  if type($symlink_vastool_binary) == 'string' {
+    $symlink_vastool_binary_bool = str2bool($symlink_vastool_binary)
+  } else {
+    $symlink_vastool_binary_bool = $symlink_vastool_binary
+  }
+  validate_bool($symlink_vastool_binary_bool)
+
+  # optionally create symlinks to vastool binary
+  if $symlink_vastool_binary_bool == true {
+    # validate params
+    validate_absolute_path($symlink_vastool_binary_target)
+    validate_absolute_path($vastool_binary)
+
+    file { 'vastool_symlink':
+      ensure => link,
+      path   => $symlink_vastool_binary_target,
+      target => $vastool_binary,
+    }
   }
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -499,4 +499,79 @@ jdoe@example.com::::::/bin/sh
 
   end
 
+  describe 'with symlink_vastool_binary' do
+    ['true',true].each do |value|
+      context "set to #{value} (default)" do
+        let(:facts) { { :kernel            => 'Linux',
+                        :osfamily          => 'Redhat',
+                        :lsbmajdistrelease => 6,
+                    } }
+        let(:params) do
+          { :symlink_vastool_binary => value, }
+        end
+
+        it {
+          should contain_file('vastool_symlink').with({
+            'path'    => '/usr/bin/vastool',
+            'target'  => '/opt/quest/bin/vastool',
+            'ensure'  => 'link',
+          })
+        }
+      end
+    end
+
+    ['false',false].each do |value|
+      context "set to #{value} (default)" do
+        let(:facts) { { :kernel            => 'Linux',
+                        :osfamily          => 'Redhat',
+                        :lsbmajdistrelease => 6,
+                    } }
+        let(:params) do
+          { :symlink_vastool_binary => value, }
+        end
+
+        it { should_not contain_file('vastool_symlink') }
+      end
+    end
+
+    context 'enabled with all params specified' do
+      let(:facts) { { :kernel            => 'Linux',
+                      :osfamily          => 'Redhat',
+                      :lsbmajdistrelease => 6,
+                  } }
+      let(:params) do
+        { :symlink_vastool_binary        => true,
+          :vastool_binary                => '/foo/bar',
+          :symlink_vastool_binary_target => '/bar',
+        }
+      end
+
+      it {
+        should contain_file('vastool_symlink').with({
+          'path'    => '/bar',
+          'target'  => '/foo/bar',
+          'ensure'  => 'link',
+        })
+      }
+    end
+
+    context 'enabled with invalid vastool_binary' do
+      let(:params) { { :symlink_vastool_binary        => true,
+                       :vastool_binary                => 'true',
+                       :symlink_vastool_binary_target => '/bar' } }
+      it do
+        expect { should }.to raise_error(Puppet::Error)
+      end
+    end
+
+    context 'enabled with invalid symlink_vastool_binary_target' do
+      let(:params) { { :symlink_vastool_binary        => true,
+                       :vastool_binary                => '/foo/bar',
+                       :symlink_vastool_binary_target => 'undef' } }
+      it do
+        expect { should }.to raise_error(Puppet::Error)
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
Default is to create a symlink from /usr/bin/vastool to
/opt/quest/bin/vastool so that it's in the path.
