### PR TITLE
Handle strings better in users.{allow,deny}

### DIFF
--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -586,8 +586,8 @@ describe 'vas' do
         }.to raise_error(Puppet::Error,/vas::vas_conf_libvas_auth_helper_timeout must be an integer. Detected value is <10invalid>./)
       end
     end
-    
-    context 'with users_allow_entries specified on osfamily redhat with lsbmajdistrelease 6' do
+
+    context 'with users_allow_entries specified as an array on osfamily redhat with lsbmajdistrelease 6' do
       let :facts do
         {
           :kernel                    => 'Linux',
@@ -621,7 +621,40 @@ DOMAIN\\adgroup
       end
     end
 
-    context 'with users_deny_entries specified on osfamily redhat with lsbmajdistrelease 6' do
+    context 'with users_allow_entries specified as a string on osfamily redhat with lsbmajdistrelease 6' do
+      let :facts do
+        {
+          :kernel                    => 'Linux',
+          :osfamily                  => 'RedHat',
+          :lsbmajdistrelease         => '6',
+          :operatingsystemmajrelease => '6',
+          :fqdn                      => 'host.example.com',
+          :domain                    => 'example.com',
+        }
+      end
+      let :params do
+        {
+          :users_allow_entries => 'DOMAIN\adgroup',
+        }
+      end
+
+      it do
+        should contain_file('vas_users_allow').with({
+          'ensure'  => 'present',
+          'path'    => '/etc/opt/quest/vas/users.allow',
+          'owner'   => 'root',
+          'group'   => 'root',
+          'mode'    => '0644',
+        })
+        should contain_file('vas_users_allow').with_content(
+%{# This file is being maintained by Puppet.
+# DO NOT EDIT
+DOMAIN\\adgroup
+})
+      end
+    end
+
+    context 'with users_deny_entries specified as an array on osfamily redhat with lsbmajdistrelease 6' do
       let :facts do
         {
           :kernel                    => 'Linux',
@@ -650,6 +683,39 @@ DOMAIN\\adgroup
 %{# This file is being maintained by Puppet.
 # DO NOT EDIT
 user@realm.com
+DOMAIN\\adgroup
+})
+      end
+    end
+
+    context 'with users_deny_entries specified as a string on osfamily redhat with lsbmajdistrelease 6' do
+      let :facts do
+        {
+          :kernel                    => 'Linux',
+          :osfamily                  => 'RedHat',
+          :lsbmajdistrelease         => '6',
+          :operatingsystemmajrelease => '6',
+          :fqdn                      => 'host.example.com',
+          :domain                    => 'example.com',
+        }
+      end
+      let :params do
+        {
+          :users_deny_entries => 'DOMAIN\adgroup',
+        }
+      end
+
+      it do
+        should contain_file('vas_users_deny').with({
+          'ensure'  => 'present',
+          'path'    => '/etc/opt/quest/vas/users.deny',
+          'owner'   => 'root',
+          'group'   => 'root',
+          'mode'    => '0644',
+        })
+        should contain_file('vas_users_deny').with_content(
+%{# This file is being maintained by Puppet.
+# DO NOT EDIT
 DOMAIN\\adgroup
 })
       end

--- a/templates/users.allow.erb
+++ b/templates/users.allow.erb
@@ -1,7 +1,13 @@
 # This file is being maintained by Puppet.
 # DO NOT EDIT
+<% if @users_allow_entries_real -%>
+<% if @users_allow_entries_real.is_a?(Array) -%>
 <% @users_allow_entries_real.each do |allowentry| -%>
 <% if allowentry != 'UNSET' -%>
 <%= allowentry %>
+<% end -%>
+<% end -%>
+<% else -%>
+<%= @users_allow_entries_real %>
 <% end -%>
 <% end -%>

--- a/templates/users.deny.erb
+++ b/templates/users.deny.erb
@@ -1,7 +1,13 @@
 # This file is being maintained by Puppet.
 # DO NOT EDIT
+<% if @users_deny_entries_real -%>
+<% if @users_deny_entries_real.is_a?(Array) -%>
 <% @users_deny_entries_real.each do |denyentry| -%>
 <% if denyentry != 'UNSET' -%>
 <%= denyentry %>
+<% end -%>
+<% end -%>
+<% else -%>
+<%= @users_deny_entries_real %>
 <% end -%>
 <% end -%>


### PR DESCRIPTION
Puppetserver's ruby intepreter is more strict than the previously used intepreter used by Puppet. It's no longer allow to do *.each* on strings. This commit prevents the error below from occuring if users_{allow,deny}_entries is an string.

````
Could not retrieve catalog from remote server: Error 400 on SERVER: Failed to parse template vas/users.allow.erb: Filepath: .../modules/vas/templates/users.allow.erb Line: 3 Detail: undefined method `each' for "":String at .../modules/vas/manifests/init.pp:323 on node fqdn.
````