### PR TITLE
use absolute path for vastool exec resource

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -405,7 +405,7 @@ class vas (
   $once_file = '/etc/opt/quest/vas/puppet_joined'
 
   exec { 'vasinst':
-    command => "vastool -u ${username} -k ${keytab_path} -d3 join -f ${workstation_flag} -c ${computers_ou} -p ${users_ou} -n ${vas_fqdn} ${s_opts} ${realm} > ${vasjoin_logfile} 2>&1 && touch ${once_file}",
+    command => "${vastool_binary} -u ${username} -k ${keytab_path} -d3 join -f ${workstation_flag} -c ${computers_ou} -p ${users_ou} -n ${vas_fqdn} ${s_opts} ${realm} > ${vasjoin_logfile} 2>&1 && touch ${once_file}",
     path    => '/bin:/usr/bin:/opt/quest/bin',
     timeout => 1800,
     creates => $once_file,


### PR DESCRIPTION
Ubuntu doesn't know the path to vastool. So I reused $vastool_binary in the exec resource to have a absolute path instead.