### PR TITLE
Increased support for Workstation mode with RFC2307

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,19 +135,37 @@ computers_ou
 ------------
 Path to OU where to store computer object.
 
-- *Default*: 'ou=computers,dc=example,dc=com'
+- *Default*: 'UNSET'
 
 users_ou
 --------
-Path to OU where to load users initially.
+Deprecated, this parameter is the same as upm_search_path. Path to OU where to load UPM user profiles.
 
-- *Default*: 'ou=users,dc=example,dc=com'
+- *Default*: 'UNSET'
 
 nismaps_ou
 ----------
 Path to OU where to load nismaps initially.
 
-- *Default*: 'ou=nismaps,dc=example,dc=com'
+- *Default*: 'UNSET'
+
+upm_search_path
+---------------
+LDAP search path for UPM user profiles. Setting this parameter will cause QAS to run in UPM mode.
+
+- *Default*: 'UNSET'
+
+user_search_path
+----------------
+LDAP search path for user profiles. This will limit the scope where QAS will search for users when operating in RFC2307 mode.
+
+- *Default*: 'UNSET'
+
+group_search_path
+-----------------
+LDAP search path for groups. This will limit the scope where QAS will search for groups when operating in RFC2307 mode.
+
+- *Default*: 'UNSET'
 
 realm
 -----
@@ -172,6 +190,22 @@ vas_conf_client_addrs
 client-addrs option in vas.conf. See VAS.CONF(5) for more info.
 
 - *Default*: 'UNSET'
+
+vas_conf_root_update_mode
+-------------------------
+The value of root-update-mode in the [nss_vas] configuration section. This controls how directory searches will be performed when calling nss functions. See VAS.CONF(5) for more info.
+
+Possible values: force | force-if-missing | none
+
+- *Default*: 'none'
+
+vas_conf_group_update_mode
+--------------------------
+The value of group-update-mode in the [nss_vas] configuration section. This controls how directory searches will be handeled for group nss functions. See VAS.CONF(5) for more info.
+
+Possible values: force | force-if-missing | none
+
+- *Default*: 'none'
 
 vas_conf_disabled_user_pwhash
 -----------------------------

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,12 +18,12 @@ class vas (
   $keytab_group                                         = 'root',
   $keytab_mode                                          = '0400',
   $vas_fqdn                                             = $::fqdn,
-  $computers_ou                                         = 'ou=computers,dc=example,dc=com',
-  $users_ou                                             = 'ou=users,dc=example,dc=com',
+  $computers_ou                                         = 'UNSET',
+  $users_ou                                             = 'UNSET',
   $nismaps_ou                                           = 'ou=nismaps,dc=example,dc=com',
-  $user_search_path                                     = undef,
-  $group_search_path                                    = undef,
-  $upm_search_path                                      = undef,
+  $user_search_path                                     = 'UNSET',
+  $group_search_path                                    = 'UNSET',
+  $upm_search_path                                      = 'UNSET',
   $nisdomainname                                        = undef,
   $realm                                                = 'realm.example.com',
   $sitenameoverride                                     = 'UNSET',
@@ -111,6 +111,13 @@ class vas (
   validate_re($vas_conf_libvas_vascache_ipc_timeout, '^\d+$', "vas::vas_conf_libvas_vascache_ipc_timeout must be an integer. Detected value is <${vas_conf_libvas_vascache_ipc_timeout}>.")
   validate_re($vas_conf_libvas_auth_helper_timeout, '^\d+$', "vas::vas_conf_libvas_auth_helper_timeout must be an integer. Detected value is <${vas_conf_libvas_auth_helper_timeout}>.")
   validate_string($vas_conf_prompt_vas_ad_pw)
+
+  validate_string($user_search_path)
+  validate_string($group_search_path)
+  validate_string($upm_search_path)
+  validate_string($users_ou)
+  validate_string($computers_ou)
+  validate_string($nismaps_ou)
 
   validate_absolute_path($vas_config_path)
   if $vas_conf_vasd_delusercheck_script != 'UNSET' {
@@ -251,8 +258,8 @@ class vas (
   }
 
   # Define search paths
-  if $upm_search_path == undef {
-    if $users_ou != undef {
+  if $upm_search_path == 'UNSET' {
+    if $users_ou != 'UNSET' {
       $upm_search_path_real = $users_ou
     } else {
       $upm_search_path_real = undef
@@ -260,6 +267,19 @@ class vas (
   } else {
     $upm_search_path_real = $upm_search_path
   }
+
+  if $user_search_path == 'UNSET' {
+    $user_search_path_real = undef
+  } else {
+    $user_search_path_real = $user_search_path
+  }
+
+  if $group_search_path == 'UNSET' {
+    $group_search_path_real = undef
+  } else {
+    $group_search_path_real = $group_search_path
+  }
+
 
   case $::kernel {
     'Linux': {
@@ -433,12 +453,12 @@ class vas (
     $user_search_path_parm = ""
   }
   if $group_search_path_real != undef {
-    $group_search_path_parm = "-u ${group_search_path_real}"
+    $group_search_path_parm = "-g ${group_search_path_real}"
   } else {
     $group_search_path_parm = ""
   }
   if $upm_search_path_real != undef {
-    $upm_search_path_parm = "-u ${upm_search_path_real}"
+    $upm_search_path_parm = "-p ${upm_search_path_real}"
   } else {
     $upm_search_path_parm = ""
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,11 +21,16 @@ class vas (
   $computers_ou                                         = 'ou=computers,dc=example,dc=com',
   $users_ou                                             = 'ou=users,dc=example,dc=com',
   $nismaps_ou                                           = 'ou=nismaps,dc=example,dc=com',
+  $user_search_path                                     = undef,
+  $group_search_path                                    = undef,
+  $upm_search_path                                      = undef,
   $nisdomainname                                        = undef,
   $realm                                                = 'realm.example.com',
   $sitenameoverride                                     = 'UNSET',
   $vas_conf_client_addrs                                = 'UNSET',
   $vas_conf_full_update_interval                        = 'UNSET',
+  $vas_conf_group_update_mode                           = 'none',
+  $vas_conf_root_update_mode                            = 'none',
   $vas_conf_disabled_user_pwhash                        = undef,
   $vas_conf_locked_out_pwhash                           = undef,
   $vas_conf_preload_nested_memberships                  = 'UNSET',
@@ -132,6 +137,14 @@ class vas (
     validate_string($vas_conf_locked_out_pwhash)
   }
 
+  if $vas_conf_group_update_mode != undef {
+    validate_string($vas_conf_group_update_mode)
+  }
+
+  if $vas_conf_root_update_mode != undef {
+    validate_string($vas_conf_root_update_mode)
+  }
+
   if $license_files != undef {
     validate_hash($license_files)
 
@@ -235,6 +248,17 @@ class vas (
     $vas_conf_vasd_timesync_interval_real = $default_vas_conf_vasd_timesync_interval
   } else {
     $vas_conf_vasd_timesync_interval_real = $vas_conf_vasd_timesync_interval
+  }
+
+  # Define search paths
+  if $upm_search_path == undef {
+    if $users_ou != undef {
+      $upm_search_path_real = $users_ou
+    } else {
+      $upm_search_path_real = undef
+    }
+  } else {
+    $upm_search_path_real = $upm_search_path
   }
 
   case $::kernel {
@@ -403,10 +427,26 @@ class vas (
     $workstation_flag = ""
   }
 
+  if $user_search_path_real != undef {
+    $user_search_path_parm = "-u ${user_search_path_real}"
+  } else {
+    $user_search_path_parm = ""
+  }
+  if $group_search_path_real != undef {
+    $group_search_path_parm = "-u ${group_search_path_real}"
+  } else {
+    $group_search_path_parm = ""
+  }
+  if $upm_search_path_real != undef {
+    $upm_search_path_parm = "-u ${upm_search_path_real}"
+  } else {
+    $upm_search_path_parm = ""
+  }
+
   $once_file = '/etc/opt/quest/vas/puppet_joined'
 
   exec { 'vasinst':
-    command => "${vastool_binary} -u ${username} -k ${keytab_path} -d3 join -f ${workstation_flag} -c ${computers_ou} -p ${users_ou} -n ${vas_fqdn} ${s_opts} ${realm} > ${vasjoin_logfile} 2>&1 && touch ${once_file}",
+    command => "${vastool_binary} -u ${username} -k ${keytab_path} -d3 join -f ${workstation_flag} -c ${computers_ou} ${user_search_path_parm} ${group_search_path_parm} ${upm_search_path_parm} -n ${vas_fqdn} ${s_opts} ${realm} > ${vasjoin_logfile} 2>&1 && touch ${once_file}",
     path    => '/bin:/usr/bin:/opt/quest/bin',
     timeout => 1800,
     creates => $once_file,

--- a/templates/vas.conf.erb
+++ b/templates/vas.conf.erb
@@ -50,7 +50,9 @@
 
 [vasd]
  update-interval = <%= @vas_conf_vasd_update_interval %>
- upm-search-path = <%= @users_ou %>
+<% if @upm_search_path_real -%>
+ upm-search-path = <%= @upm_search_path %>
+<% end -%>
  workstation-mode = <%= @vas_conf_vasd_workstation_mode_real %>
 <% if @vas_conf_vasd_workstation_mode_real -%>
 <%   if @vas_conf_vasd_workstation_mode_users_preload != 'UNSET' -%>
@@ -59,6 +61,12 @@
  workstation-mode-group-do-member = <%= @vas_conf_vasd_workstation_mode_group_do_member_real %>
  workstation-mode-groups-skip-update = <%= @vas_conf_vasd_workstation_mode_groups_skip_update_real %>
  ws-resolve-uid = <%= @vas_conf_vasd_ws_resolve_uid_real %>
+<% end -%>
+<% if @user_search_path -%>
+  user-search-path = <%= @user_search_path %>
+<% end -%>
+<% if @group_search_path -%>
+  group-search-path = <%= @group_search_path %>
 <% end -%>
 <% if @vas_user_override_path != 'UNSET' %>
  user-override-file = <%= @vas_user_override_path %>
@@ -97,8 +105,12 @@
 <% end -%>
 
 [nss_vas]
- group-update-mode = none
- root-update-mode = none
+<% if @vas_conf_group_update_mode != nil -%>
+ group-update-mode = <%= @vas_conf_group_update_mode %>
+<% end -%>
+<% if @vas_conf_root_update_mode != nil -%>
+ root-update-mode = <%= @vas_conf_root_update_mode %>
+<% end -%>
 <% if @vas_conf_disabled_user_pwhash != nil -%>
  disabled-user-pwhash = <%= @vas_conf_disabled_user_pwhash  %>
 <% end -%>

--- a/templates/vas.conf.erb
+++ b/templates/vas.conf.erb
@@ -51,7 +51,7 @@
 [vasd]
  update-interval = <%= @vas_conf_vasd_update_interval %>
 <% if @upm_search_path_real -%>
- upm-search-path = <%= @upm_search_path %>
+ upm-search-path = <%= @upm_search_path_real %>
 <% end -%>
  workstation-mode = <%= @vas_conf_vasd_workstation_mode_real %>
 <% if @vas_conf_vasd_workstation_mode_real -%>
@@ -62,11 +62,11 @@
  workstation-mode-groups-skip-update = <%= @vas_conf_vasd_workstation_mode_groups_skip_update_real %>
  ws-resolve-uid = <%= @vas_conf_vasd_ws_resolve_uid_real %>
 <% end -%>
-<% if @user_search_path -%>
-  user-search-path = <%= @user_search_path %>
+<% if @user_search_path_real -%>
+ user-search-path = <%= @user_search_path_real %>
 <% end -%>
-<% if @group_search_path -%>
-  group-search-path = <%= @group_search_path %>
+<% if @group_search_path_real -%>
+ group-search-path = <%= @group_search_path_real %>
 <% end -%>
 <% if @vas_user_override_path != 'UNSET' %>
  user-override-file = <%= @vas_user_override_path %>


### PR DESCRIPTION
The default values for computers_ou and users_ou has been changed from
dummy values to 'UNSET' to be able to more reliably check whether they
are set or not. This means that the users_ou parameter is no longer
mandatory and can be ignored if RFC2307 mode is desired.

The general idea it that users_ou will be deprecated in favor of
upm_search_path, which better represents what the parameter is
controlling. This is to conform with parameters user_search_path and
group_search_path that is used to restrict the scope in RFC2307 mode.

Additionally control of the parameters root-update-mode and
group-update-mode has been added to be able to work around a problem
seen when using Workstation mode in RFC2307 mode. When this parameter is
set to none, which previously was hard coded in the vas.conf template,
users was sometimes not able to login. The default value is still 'none'
