### PR TITLE
Ubuntu 14.04 12.04 verifyed, fixed missing /sbin 

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This module has been tested to work on the following systems using Puppet v3 and
  * Suse 10
  * Suse 11
  * Ubuntu 12.04
+ * Ubuntu 14.04
  * Solaris 9
  * Solaris 10
  * Solaris 11

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -467,7 +467,7 @@ class vas (
 
   exec { 'vasinst':
     command => "${vastool_binary} -u ${username} -k ${keytab_path} -d3 join -f ${workstation_flag} -c ${computers_ou} ${user_search_path_parm} ${group_search_path_parm} ${upm_search_path_parm} -n ${vas_fqdn} ${s_opts} ${realm} > ${vasjoin_logfile} 2>&1 && touch ${once_file}",
-    path    => '/bin:/usr/bin:/opt/quest/bin',
+    path    => '/sbin:/bin:/usr/bin:/opt/quest/bin',
     timeout => 1800,
     creates => $once_file,
     require => [Package['vasclnt','vasyp','vasgp'],File['keytab']],


### PR DESCRIPTION
merge "use absolute path for vastool exec resource" breaks ubuntu 12.04 and 14.04. 
add /sbin and verifyed ubuntu 12.04 and 14.04 