### PR TITLE
prepare for Puppet v4

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -7,6 +7,6 @@ fixtures:
     'rpcbind': 'git://github.com/ghoneycutt/puppet-module-rpcbind.git'
     'stdlib':
       repo: 'git://github.com/puppetlabs/puppetlabs-stdlib.git'
-      ref: '3.2.0'
+      ref: '4.6.0'
   symlinks:
     vas: "#{source_dir}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+# Default .gitignore for Ruby
 *.gem
 *.rbc
 .bundle
@@ -16,3 +17,18 @@ tmp
 .yardoc
 _yardoc
 doc/
+
+# Vim
+*.swp
+
+# OS X
+.DS_Store
+
+# Puppet
+coverage/
+spec/fixtures/modules/*
+spec/fixtures/manifests/*
+Gemfile.lock
+
+# Geppetto
+.project

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,32 @@
 ---
+language: ruby
+
+rvm:
+  - 1.8.7
+  - 1.9.3
+  - 2.0.0
+  - 2.1.0
+
 env:
   matrix:
     - PUPPET_GEM_VERSION="~> 3.1.0"
     - PUPPET_GEM_VERSION="~> 3.2.0"
     - PUPPET_GEM_VERSION="~> 3.3.0"
     - PUPPET_GEM_VERSION="~> 3.4.0"
-    - PUPPET_GEM_VERSION="~> 3.5.1"
-    - PUPPET_GEM_VERSION="~> 3.6.2"
-    - PUPPET_GEM_VERSION="~> 3.7.1"
-notifications:
-email: false
-rvm:
-- 1.8.7
-- 1.9.3
-- 2.0.0
-- 2.1.0
+    - PUPPET_GEM_VERSION="~> 3.5.0"
+    - PUPPET_GEM_VERSION="~> 3.6.0"
+    - PUPPET_GEM_VERSION="~> 3.7.0"
+    - PUPPET_GEM_VERSION="~> 3.8.0"
+    - PUPPET_GEM_VERSION="~> 3" PARSER="future"
+    - PUPPET_GEM_VERSION="~> 4.0.0"
+    - PUPPET_GEM_VERSION="~> 4.1.0"
+    - PUPPET_GEM_VERSION="~> 4.2.0"
+    - PUPPET_GEM_VERSION="~> 4"
+
+sudo: false
+
+script: 'bundle exec metadata-json-lint metadata.json && bundle exec rake validate && bundle exec rake lint && SPEC_OPTS="--format documentation" bundle exec rake spec'
+
 matrix:
   fast_finish: true
   exclude:
@@ -28,7 +40,14 @@ matrix:
       env: PUPPET_GEM_VERSION="~> 3.3.0"
     - rvm: 2.1.0
       env: PUPPET_GEM_VERSION="~> 3.4.0"
-language: ruby
-before_script: 'gem install --no-ri --no-rdoc bundler'
-script: 'bundle exec rake validate && bundle exec rake lint && SPEC_OPTS="--format documentation" bundle exec rake spec'
-gemfile: Gemfile
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.0.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.1.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.2.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4"
+
+notifications:
+  email: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,18 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
-puppetversion = ENV.key?('PUPPET_VERSION') ? "= #{ENV['PUPPET_VERSION']}" : ['>= 3.3']
-gem 'puppet', puppetversion
+if puppetversion = ENV['PUPPET_GEM_VERSION']
+  gem 'puppet', puppetversion, :require => false
+else
+  gem 'puppet', :require => false
+end
+
+gem 'metadata-json-lint'
 gem 'puppetlabs_spec_helper', '>= 0.1.0'
 gem 'puppet-lint', '>= 1.0.0'
-gem 'facter', '>= 1.7.0', "< 1.8.0"
-gem 'rspec-puppet', '~>1.0'
-gem 'rspec', '~>2.0'
-gem 'metadata-json-lint'
+gem 'facter', '>= 1.7.0'
+gem 'rspec-puppet'
+
+# rspec must be v2 for ruby 1.8.7
+if RUBY_VERSION >= '1.8.7' and RUBY_VERSION < '1.9'
+  gem 'rspec', '~> 2.0'
+end

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ Puppet module to manage DELL Authentication Services previously known as VAS or 
 
 # Compatibility
 
-This module has been tested to work on the following systems using Puppet v3 and Ruby 1.8.7
+This module has been tested to work on the following systems with Puppet v3
+(with and without the future parser) and Puppet v4 with Ruby versions 1.8.7,
+1.9.3, 2.0.0 and 2.1.0.
 
  * RHEL 5
  * RHEL 6

--- a/Rakefile
+++ b/Rakefile
@@ -1,12 +1,18 @@
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-lint/tasks/puppet-lint'
+
 PuppetLint.configuration.send('disable_80chars')
-PuppetLint.configuration.relative = true
-PuppetLint.configuration.ignore_paths = ["spec/**/*.pp"]
+PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp"]
 
 desc "Run puppet in noop mode and check for syntax errors."
 task :validate do
-   Dir['manifests/**/*.pp'].each do |path|
-     sh "puppet parser validate --noop #{path}"
-   end
+  Dir['manifests/**/*.pp'].each do |manifest|
+    sh "puppet parser validate --noop #{manifest}"
+  end
+  Dir['spec/**/*.rb','lib/**/*.rb'].each do |ruby_file|
+    sh "ruby -c #{ruby_file}" unless ruby_file =~ /spec\/fixtures/
+  end
+  Dir['templates/**/*.erb'].each do |template|
+    sh "erb -P -x -T '-' #{template} | ruby -c"
+  end
 end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -112,16 +112,16 @@ class vas (
   }
 
   # validate params
-  validate_re($vas_conf_vasd_auto_ticket_renew_interval, '^\d+$', "vas::vas_conf_vasd_auto_ticket_renew_interval must be an integer. Detected value is <${vas_conf_vasd_auto_ticket_renew_interval}>.")
-  validate_re($vas_conf_vasd_update_interval, '^\d+$', "vas::vas_conf_vasd_update_interval must be an integer. Detected value is <${vas_conf_vasd_update_interval}>.")
+  validate_integer($vas_conf_vasd_update_interval)
+  validate_integer($vas_conf_vasd_auto_ticket_renew_interval)
   if $vas_conf_vasd_deluser_check_timelimit != 'UNSET' {
-    validate_re($vas_conf_vasd_deluser_check_timelimit, '^\d+$', "vas::vas_conf_vasd_deluser_check_timelimit must be an integer. Detected value is <${vas_conf_vasd_deluser_check_timelimit}>.")
+    validate_integer($vas_conf_vasd_deluser_check_timelimit)
   }
   if $vas_conf_vasd_delusercheck_interval != 'UNSET' {
-    validate_re($vas_conf_vasd_delusercheck_interval, '^\d+$', "vas::vas_conf_vasd_delusercheck_interval must be an integer. Detected value is <${vas_conf_vasd_delusercheck_interval}>.")
+    validate_integer($vas_conf_vasd_delusercheck_interval)
   }
-  validate_re($vas_conf_libvas_vascache_ipc_timeout, '^\d+$', "vas::vas_conf_libvas_vascache_ipc_timeout must be an integer. Detected value is <${vas_conf_libvas_vascache_ipc_timeout}>.")
-  validate_re($vas_conf_libvas_auth_helper_timeout, '^\d+$', "vas::vas_conf_libvas_auth_helper_timeout must be an integer. Detected value is <${vas_conf_libvas_auth_helper_timeout}>.")
+  validate_integer($vas_conf_libvas_vascache_ipc_timeout)
+  validate_integer($vas_conf_libvas_auth_helper_timeout)
   validate_string($vas_conf_prompt_vas_ad_pw)
 
   validate_string($user_search_path)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -102,13 +102,10 @@ class vas (
   $_vas_user_override_path_default = '/etc/opt/quest/vas/user-override'
   $_vas_group_override_path_default = '/etc/opt/quest/vas/group-override'
 
-  case versioncmp($::vas_version, $vas_conf_libvas_use_server_referrals_version_switch) {
-    '0','1': {
-      $vas_conf_libvas_use_server_referrals_default = false
-    }
-    default: {
-      $vas_conf_libvas_use_server_referrals_default = true
-    }
+  if versioncmp($::vas_version, $vas_conf_libvas_use_server_referrals_version_switch) >= 0 {
+    $vas_conf_libvas_use_server_referrals_default = false
+  } else {
+    $vas_conf_libvas_use_server_referrals_default = true
   }
 
   # validate params

--- a/manifests/linux.pp
+++ b/manifests/linux.pp
@@ -8,7 +8,12 @@ class vas::linux inherits vas {
     }
 
     'Debian','Suse','RedHat': {
-      $vasver = regsubst($vas::package_version, '-', '.')
+      if $vas::package_version != undef {
+        $vasver = regsubst($vas::package_version, '-', '.')
+      } else {
+        $vasver = ''
+      }
+
       if ($::vas_version and $vasver > $::vas_version and $vas::package_version != 'UNSET') {
         $upgrade = true
       } else {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -430,7 +430,7 @@ describe 'vas' do
 
       it 'should fail' do
         expect {
-          should include_class('vas')
+          should contain_class('vas')
         }.to raise_error(Puppet::Error,/vas::vas_fqdn is not a valid FQDN. Detected value is <bad!@#hostname>./)
       end
     end
@@ -453,7 +453,7 @@ describe 'vas' do
 
       it 'should fail' do
         expect {
-          should include_class('vas')
+          should contain_class('vas')
         }.to raise_error(Puppet::Error,/Unknown type of boolean given/)
       end
     end
@@ -475,7 +475,7 @@ describe 'vas' do
 
       it 'should fail' do
         expect {
-          should include_class('vas')
+          should contain_class('vas')
         }.to raise_error(Puppet::Error,/vas::vas_conf_vasd_auto_ticket_renew_interval must be an integer. Detected value is <600invalid>./)
       end
     end
@@ -497,7 +497,7 @@ describe 'vas' do
 
       it 'should fail' do
         expect {
-          should include_class('vas')
+          should contain_class('vas')
         }.to raise_error(Puppet::Error,/vas::vas_conf_vasd_update_interval must be an integer. Detected value is <600invalid>./)
       end
     end
@@ -519,7 +519,7 @@ describe 'vas' do
 
       it 'should fail' do
         expect {
-          should include_class('vas')
+          should contain_class('vas')
         }.to raise_error(Puppet::Error,/is not a string/)
       end
     end
@@ -541,7 +541,7 @@ describe 'vas' do
 
       it 'should fail' do
         expect {
-          should include_class('vas')
+          should contain_class('vas')
         }.to raise_error(Puppet::Error,/is not a string/)
       end
     end
@@ -563,7 +563,7 @@ describe 'vas' do
 
       it 'should fail' do
         expect {
-          should include_class('vas')
+          should contain_class('vas')
         }.to raise_error(Puppet::Error,/is not a string/)
       end
     end
@@ -585,7 +585,7 @@ describe 'vas' do
 
       it 'should fail' do
         expect {
-          should include_class('vas')
+          should contain_class('vas')
         }.to raise_error(Puppet::Error)
       end
     end
@@ -607,7 +607,7 @@ describe 'vas' do
 
       it 'should fail' do
         expect {
-          should include_class('vas')
+          should contain_class('vas')
         }.to raise_error(Puppet::Error)
       end
     end
@@ -629,7 +629,7 @@ describe 'vas' do
 
       it 'should fail' do
         expect {
-          should include_class('vas')
+          should contain_class('vas')
         }.to raise_error(Puppet::Error)
       end
     end
@@ -651,7 +651,7 @@ describe 'vas' do
 
       it 'should fail' do
         expect {
-          should include_class('vas')
+          should contain_class('vas')
         }.to raise_error(Puppet::Error)
       end
     end
@@ -673,7 +673,7 @@ describe 'vas' do
 
       it 'should fail' do
         expect {
-          should include_class('vas')
+          should contain_class('vas')
         }.to raise_error(Puppet::Error)
       end
     end
@@ -695,7 +695,7 @@ describe 'vas' do
 
       it 'should fail' do
         expect {
-          should include_class('vas')
+          should contain_class('vas')
         }.to raise_error(Puppet::Error,/vas::vas_conf_libvas_auth_helper_timeout must be an integer. Detected value is <10invalid>./)
       end
     end
@@ -1072,10 +1072,10 @@ DOMAIN\\adgroup:group::
           :kernel => 'AIX',
         }
       end
-      it do
+      it 'should fail' do
         expect {
-          should include_class('vas')
-        }.to raise_error(Puppet::Error,/Vas module support Linux and SunOS kernels./)
+          should contain_class('vas')
+        }.to raise_error(Puppet::Error,/Vas module support Linux and SunOS kernels\./)
       end
     end
 
@@ -1086,10 +1086,10 @@ DOMAIN\\adgroup:group::
           :osfamily => 'Gentoo',
         }
       end
-      it do
+      it 'should fail' do
         expect {
-          should include_class('vas')
-        }.to raise_error(Puppet::Error,/Vas supports Debian, Suse, and RedHat./)
+          should contain_class('vas')
+        }.to raise_error(Puppet::Error,/Vas supports Debian, Suse, and RedHat\./)
       end
     end
 
@@ -1159,7 +1159,9 @@ DOMAIN\\adgroup:group::
                        :vastool_binary                => 'true',
                        :symlink_vastool_binary_target => '/bar' } }
       it 'should fail' do
-        expect { should }.to raise_error(Puppet::Error, /Vas module support Linux and SunOS kernels. Detected kernel is <>/)
+        expect {
+          should contain_class('vas')
+        }.to raise_error(Puppet::Error,/Vas module support Linux and SunOS kernels. Detected kernel is <>/)
       end
     end
 
@@ -1168,7 +1170,9 @@ DOMAIN\\adgroup:group::
                        :vastool_binary                => '/foo/bar',
                        :symlink_vastool_binary_target => 'undef' } }
       it 'should fail' do
-        expect { should }.to raise_error(Puppet::Error, /Vas module support Linux and SunOS kernels. Detected kernel is <>/)
+        expect {
+          should contain_class('vas')
+        }.to raise_error(Puppet::Error,/Vas module support Linux and SunOS kernels\. Detected kernel is <>/)
       end
     end
   end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -11,6 +11,7 @@ describe 'vas' do
         :osfamily                  => 'RedHat',
         :lsbmajdistrelease         => '6',
         :operatingsystemmajrelease => '6',
+        :vas_version               => '4.1.0.21518',
       }
       end
 
@@ -56,6 +57,7 @@ describe 'vas' do
           :osfamily                  => 'RedHat',
           :lsbmajdistrelease         => '6',
           :operatingsystemmajrelease => '6',
+          :vas_version               => '4.1.0.21518',
         }
       end
       let :params do
@@ -76,6 +78,7 @@ describe 'vas' do
           :osfamily                  => 'RedHat',
           :lsbmajdistrelease         => '6',
           :operatingsystemmajrelease => '6',
+          :vas_version               => '4.1.0.21518',
         }
       end
       let :params do
@@ -100,6 +103,7 @@ describe 'vas' do
           :operatingsystemmajrelease => '6',
           :fqdn                      => 'host.example.com',
           :domain                    => 'example.com',
+          :vas_version               => '4.1.0.21518',
         }
       end
 
@@ -225,6 +229,7 @@ describe 'vas' do
           :operatingsystemmajrelease => '6',
           :fqdn                      => 'host.example.com',
           :domain                    => 'example.com',
+          :vas_version               => '4.1.0.21518',
         }
       end
       let :params do
@@ -400,6 +405,7 @@ describe 'vas' do
           :operatingsystemmajrelease => '6',
           :fqdn                      => 'host.example.com',
           :domain                    => 'example.com',
+          :vas_version               => '4.1.0.21518',
         }
       end
       let :params do
@@ -422,6 +428,7 @@ describe 'vas' do
           :operatingsystemmajrelease => '6',
           :fqdn                      => 'host.example.com',
           :domain                    => 'example.com',
+          :vas_version               => '4.1.0.21518',
         }
       end
       let :params do
@@ -445,6 +452,7 @@ describe 'vas' do
           :operatingsystemmajrelease => '6',
           :fqdn                      => 'host.example.com',
           :domain                    => 'example.com',
+          :vas_version               => '4.1.0.21518',
         }
       end
       let :params do
@@ -467,6 +475,7 @@ describe 'vas' do
           :operatingsystemmajrelease => '6',
           :fqdn                      => 'host.example.com',
           :domain                    => 'example.com',
+          :vas_version               => '4.1.0.21518',
         }
       end
       let :params do
@@ -489,6 +498,7 @@ describe 'vas' do
           :operatingsystemmajrelease => '6',
           :fqdn                      => 'host.example.com',
           :domain                    => 'example.com',
+          :vas_version               => '4.1.0.21518',
         }
       end
       let :params do
@@ -511,6 +521,7 @@ describe 'vas' do
           :operatingsystemmajrelease => '6',
           :fqdn                      => 'host.example.com',
           :domain                    => 'example.com',
+          :vas_version               => '4.1.0.21518',
         }
       end
       let :params do
@@ -533,6 +544,7 @@ describe 'vas' do
           :operatingsystemmajrelease => '6',
           :fqdn                      => 'host.example.com',
           :domain                    => 'example.com',
+          :vas_version               => '4.1.0.21518',
         }
       end
       let :params do
@@ -555,6 +567,7 @@ describe 'vas' do
           :operatingsystemmajrelease => '6',
           :fqdn                      => 'host.example.com',
           :domain                    => 'example.com',
+          :vas_version               => '4.1.0.21518',
         }
       end
       let :params do
@@ -577,6 +590,7 @@ describe 'vas' do
           :operatingsystemmajrelease => '6',
           :fqdn                      => 'host.example.com',
           :domain                    => 'example.com',
+          :vas_version               => '4.1.0.21518',
         }
       end
       let :params do
@@ -599,6 +613,7 @@ describe 'vas' do
           :operatingsystemmajrelease => '6',
           :fqdn                      => 'host.example.com',
           :domain                    => 'example.com',
+          :vas_version               => '4.1.0.21518',
         }
       end
       let :params do
@@ -621,6 +636,7 @@ describe 'vas' do
           :operatingsystemmajrelease => '6',
           :fqdn                      => 'host.example.com',
           :domain                    => 'example.com',
+          :vas_version               => '4.1.0.21518',
         }
       end
       let :params do
@@ -643,6 +659,7 @@ describe 'vas' do
           :operatingsystemmajrelease => '6',
           :fqdn                      => 'host.example.com',
           :domain                    => 'example.com',
+          :vas_version               => '4.1.0.21518',
         }
       end
       let :params do
@@ -665,6 +682,7 @@ describe 'vas' do
           :operatingsystemmajrelease => '6',
           :fqdn                      => 'host.example.com',
           :domain                    => 'example.com',
+          :vas_version               => '4.1.0.21518',
         }
       end
       let :params do
@@ -687,6 +705,7 @@ describe 'vas' do
           :operatingsystemmajrelease => '6',
           :fqdn                      => 'host.example.com',
           :domain                    => 'example.com',
+          :vas_version               => '4.1.0.21518',
         }
       end
       let :params do
@@ -709,6 +728,7 @@ describe 'vas' do
           :operatingsystemmajrelease => '6',
           :fqdn                      => 'host.example.com',
           :domain                    => 'example.com',
+          :vas_version               => '4.1.0.21518',
         }
       end
       let :params do
@@ -743,6 +763,7 @@ DOMAIN\\adgroup
           :operatingsystemmajrelease => '6',
           :fqdn                      => 'host.example.com',
           :domain                    => 'example.com',
+          :vas_version               => '4.1.0.21518',
         }
       end
       let :params do
@@ -776,6 +797,7 @@ DOMAIN\\adgroup
           :operatingsystemmajrelease => '6',
           :fqdn                      => 'host.example.com',
           :domain                    => 'example.com',
+          :vas_version               => '4.1.0.21518',
         }
       end
       let :params do
@@ -810,6 +832,7 @@ DOMAIN\\adgroup
           :operatingsystemmajrelease => '6',
           :fqdn                      => 'host.example.com',
           :domain                    => 'example.com',
+          :vas_version               => '4.1.0.21518',
         }
       end
       let :params do
@@ -843,6 +866,7 @@ DOMAIN\\adgroup
           :operatingsystemmajrelease => '6',
           :fqdn                      => 'host.example.com',
           :domain                    => 'example.com',
+          :vas_version               => '4.1.0.21518',
         }
       end
       let :params do
@@ -878,6 +902,7 @@ jane@example.com:::::/local/home/jane:
           :operatingsystemmajrelease => '6',
           :fqdn                      => 'host.example.com',
           :domain                    => 'example.com',
+          :vas_version               => '4.1.0.21518',
         }
       end
       let :params do
@@ -912,6 +937,7 @@ jdoestring@example.com::::::/bin/sh
           :operatingsystemmajrelease => '6',
           :fqdn                      => 'host.example.com',
           :domain                    => 'example.com',
+          :vas_version               => '4.1.0.21518',
         }
       end
       let :params do
@@ -947,6 +973,7 @@ DOMAIN\\adgroup2:group2::
           :operatingsystemmajrelease => '6',
           :fqdn                      => 'host.example.com',
           :domain                    => 'example.com',
+          :vas_version               => '4.1.0.21518',
         }
       end
       let :params do
@@ -981,6 +1008,7 @@ DOMAIN\\adgroup:group::
           :operatingsystemmajrelease => '6',
           :fqdn                      => 'host.example.com',
           :domain                    => 'example.com',
+          :vas_version               => '4.1.0.21518',
         }
       end
       let :params do
@@ -1014,6 +1042,7 @@ DOMAIN\\adgroup:group::
           :operatingsystemmajrelease => '6',
           :fqdn                      => 'host.example.com',
           :domain                    => 'example.com',
+          :vas_version               => '4.1.0.21518',
         }
       end
       let :params do
@@ -1043,6 +1072,7 @@ DOMAIN\\adgroup:group::
           :operatingsystemmajrelease => '6',
           :fqdn                      => 'host.example.com',
           :domain                    => 'example.com',
+          :vas_version               => '4.1.0.21518',
         }
       end
       let :params do
@@ -1098,11 +1128,15 @@ DOMAIN\\adgroup:group::
   describe 'with symlink_vastool_binary' do
     ['true',true].each do |value|
       context "set to #{value} (default)" do
-        let(:facts) { { :kernel                    => 'Linux',
-                        :osfamily                  => 'Redhat',
-                        :lsbmajdistrelease         => '6',
-                        :operatingsystemmajrelease => '6',
-                    } }
+        let :facts do
+          {
+            :kernel                    => 'Linux',
+            :osfamily                  => 'RedHat',
+            :lsbmajdistrelease         => '6',
+            :operatingsystemmajrelease => '6',
+            :vas_version               => '4.1.0.21518',
+          }
+        end
         let(:params) do
           { :symlink_vastool_binary => value, }
         end
@@ -1119,11 +1153,15 @@ DOMAIN\\adgroup:group::
 
     ['false',false].each do |value|
       context "set to #{value} (default)" do
-        let(:facts) { { :kernel                    => 'Linux',
-                        :osfamily                  => 'Redhat',
-                        :lsbmajdistrelease         => '6',
-                        :operatingsystemmajrelease => '6',
-                    } }
+        let :facts do
+          {
+            :kernel                    => 'Linux',
+            :osfamily                  => 'RedHat',
+            :lsbmajdistrelease         => '6',
+            :operatingsystemmajrelease => '6',
+            :vas_version               => '4.1.0.21518',
+          }
+        end
         let(:params) do
           { :symlink_vastool_binary => value, }
         end
@@ -1133,11 +1171,15 @@ DOMAIN\\adgroup:group::
     end
 
     context 'enabled with all params specified' do
-      let(:facts) { { :kernel                    => 'Linux',
-                      :osfamily                  => 'Redhat',
-                      :lsbmajdistrelease         => '6',
-                      :operatingsystemmajrelease => '6',
-                  } }
+      let :facts do
+        {
+          :kernel                    => 'Linux',
+          :osfamily                  => 'RedHat',
+          :lsbmajdistrelease         => '6',
+          :operatingsystemmajrelease => '6',
+          :vas_version               => '4.1.0.21518',
+        }
+      end
       let(:params) do
         { :symlink_vastool_binary        => true,
           :vastool_binary                => '/foo/bar',
@@ -1185,6 +1227,7 @@ DOMAIN\\adgroup:group::
         :osfamily                  => 'RedHat',
         :lsbmajdistrelease         => '6',
         :operatingsystemmajrelease => '6',
+        :vas_version               => '4.1.0.21518',
       }
       end
       let :params do
@@ -1213,6 +1256,7 @@ DOMAIN\\adgroup:group::
         :osfamily                  => 'RedHat',
         :lsbmajdistrelease         => '6',
         :operatingsystemmajrelease => '6',
+        :vas_version               => '4.1.0.21518',
       }
       end
       let :params do

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -476,7 +476,7 @@ describe 'vas' do
       it 'should fail' do
         expect {
           should contain_class('vas')
-        }.to raise_error(Puppet::Error,/vas::vas_conf_vasd_auto_ticket_renew_interval must be an integer. Detected value is <600invalid>./)
+        }.to raise_error(Puppet::Error,/validate_integer/)
       end
     end
 
@@ -498,7 +498,7 @@ describe 'vas' do
       it 'should fail' do
         expect {
           should contain_class('vas')
-        }.to raise_error(Puppet::Error,/vas::vas_conf_vasd_update_interval must be an integer. Detected value is <600invalid>./)
+        }.to raise_error(Puppet::Error,/validate_integer/)
       end
     end
 
@@ -696,7 +696,7 @@ describe 'vas' do
       it 'should fail' do
         expect {
           should contain_class('vas')
-        }.to raise_error(Puppet::Error,/vas::vas_conf_libvas_auth_helper_timeout must be an integer. Detected value is <10invalid>./)
+        }.to raise_error(Puppet::Error,/validate_integer/)
       end
     end
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -415,7 +415,7 @@ describe 'vas' do
       it 'should fail' do
         expect {
           should contain_class('vas')
-        }.to raise_error(Puppet::Error,/.*\"42\" is not a boolean.*/)
+        }.to raise_error(Puppet::Error,/is not a boolean/)
       end
     end
 


### PR DESCRIPTION
This patch prepares this module for Puppet v4 compatibility.
ATTENTION: This was not tested in real life environments yet.
