### PR TITLE
Additional parameters for [vasd] section

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,69 @@ Path for script to set value of delusercheck-script in [vasd] section of vas.con
 
 - *Default*: 'UNSET'
 
+vas_conf_vasd_username_attr_name
+--------------------------------
+String to be used for username-attr-name  in [vasd] section of vas.conf. See VAS.CONF(5) for more info.
+
+- *Default*: 'UNSET'
+
+
+vas_conf_vasd_groupname_attr_name
+---------------------------------
+String to be used for groupname-attr-name  in [vasd] section of vas.conf. See VAS.CONF(5) for more info.
+
+- *Default*: 'UNSET'
+
+vas_conf_vasd_uid_number_attr_name
+----------------------------------
+String to be used for uid-number-attr-name  in [vasd] section of vas.conf. See VAS.CONF(5) for more info.
+
+- *Default*: 'UNSET'
+
+vas_conf_vasd_gid_number_attr_name
+----------------------------------
+String to be used for gid-number-attr-name  in [vasd] section of vas.conf. See VAS.CONF(5) for more info.
+
+- *Default*: 'UNSET'
+
+vas_conf_vasd_gecos_attr_name
+-----------------------------
+String to be used for gecos-attr-name  in [vasd] section of vas.conf. See VAS.CONF(5) for more info.
+
+- *Default*: 'UNSET'
+
+vas_conf_vasd_home_dir_attr_name
+--------------------------------
+String to be used for home-dir-attr-name  in [vasd] section of vas.conf. See VAS.CONF(5) for more info.
+
+- *Default*: 'UNSET'
+
+vas_conf_vasd_login_shell_attr_name
+-----------------------------------
+String to be used for login-shell-attr-name  in [vasd] section of vas.conf. See VAS.CONF(5) for more info.
+
+- *Default*: 'UNSET'
+
+vas_conf_vasd_group_member_attr_name
+------------------------------------
+String to be used for group-member-attr-name  in [vasd] section of vas.conf. See VAS.CONF(5) for more info.
+
+- *Default*: 'UNSET'
+
+vas_conf_vasd_memberof_attr_name
+--------------------------------
+String to be used for memberof-attr-name  in [vasd] section of vas.conf. See VAS.CONF(5) for more info.
+
+- *Default*: 'UNSET'
+
+vas_conf_vasd_unix_password_attr_name
+-------------------------------------
+String to be used for unix_password-attr-name  in [vasd] section of vas.conf. See VAS.CONF(5) for more info.
+
+- *Default*: 'UNSET'
+
+
+
 vas_conf_prompt_vas_ad_pw
 -------------------------
 prompt-vas-ad-pw option in vas.conf. Sets the password prompt for logins.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -54,6 +54,16 @@ class vas (
   $vas_conf_vasd_deluser_check_timelimit                = 'UNSET',
   $vas_conf_vasd_delusercheck_interval                  = 'UNSET',
   $vas_conf_vasd_delusercheck_script                    = 'UNSET',
+  $vas_conf_vasd_username_attr_name                     = 'UNSET',
+  $vas_conf_vasd_groupname_attr_name                    = 'UNSET',
+  $vas_conf_vasd_uid_number_attr_name                   = 'UNSET',
+  $vas_conf_vasd_gid_number_attr_name                   = 'UNSET',
+  $vas_conf_vasd_gecos_attr_name                        = 'UNSET',
+  $vas_conf_vasd_home_dir_attr_name                     = 'UNSET',
+  $vas_conf_vasd_login_shell_attr_name                  = 'UNSET',
+  $vas_conf_vasd_group_member_attr_name                 = 'UNSET',
+  $vas_conf_vasd_memberof_attr_name                     = 'UNSET',
+  $vas_conf_vasd_unix_password_attr_name                = 'UNSET',
   $vas_conf_prompt_vas_ad_pw                            = '"Enter Windows password: "',
   $vas_conf_pam_vas_prompt_ad_lockout_msg               = 'UNSET',
   $vas_conf_libdefaults_forwardable                     = true,
@@ -133,6 +143,17 @@ class vas (
   validate_string($users_ou)
   validate_string($computers_ou)
   validate_string($nismaps_ou)
+
+  validate_string($vas_conf_vasd_username_attr_name)
+  validate_string($vas_conf_vasd_groupname_attr_name)
+  validate_string($vas_conf_vasd_uid_number_attr_name)
+  validate_string($vas_conf_vasd_gid_number_attr_name)
+  validate_string($vas_conf_vasd_gecos_attr_name)
+  validate_string($vas_conf_vasd_home_dir_attr_name)
+  validate_string($vas_conf_vasd_login_shell_attr_name)
+  validate_string($vas_conf_vasd_group_member_attr_name)
+  validate_string($vas_conf_vasd_memberof_attr_name)
+  validate_string($vas_conf_vasd_unix_password_attr_name)
 
   if is_string($domain_change) {
     $domain_change_real = str2bool($domain_change)

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -256,6 +256,16 @@ describe 'vas' do
           :vas_conf_vasd_workstation_mode_users_preload         => 'usergroup',
           :vas_conf_vasd_workstation_mode_group_do_member       => 'true',
           :vas_conf_vasd_workstation_mode_groups_skip_update    => 'true',
+          :vas_conf_vasd_username_attr_name                     => 'userprincipalname',
+          :vas_conf_vasd_groupname_attr_name                    => 'groupprincipalname',
+          :vas_conf_vasd_uid_number_attr_name                   => 'employeID',
+          :vas_conf_vasd_gid_number_attr_name                   => 'primaryGroupID',
+          :vas_conf_vasd_gecos_attr_name                        => 'displayName',
+          :vas_conf_vasd_home_dir_attr_name                     => 'homeDirectory',
+          :vas_conf_vasd_login_shell_attr_name                  => 'loginShell',
+          :vas_conf_vasd_group_member_attr_name                 => 'groupMembershipSAM',
+          :vas_conf_vasd_memberof_attr_name                     => 'memberOf',
+          :vas_conf_vasd_unix_password_attr_name                => 'userPassword',
           :vas_conf_vasd_ws_resolve_uid                         => 'true',
           :vas_conf_vasd_lazy_cache_update_interval             => '5',
           :vas_conf_vasd_password_change_script_timelimit       => '30',
@@ -337,6 +347,16 @@ describe 'vas' do
  upm-computerou-attr = managedBy
  password-change-script = /opt/quest/libexec/vas-set-samba-password
  password-change-script-timelimit = 30
+ username-attr-name = userprincipalname
+ groupname-attr-name = groupprincipalname
+ uid-number-attr-name = employeID
+ gid-number-attr-name = primaryGroupID
+ gecos-attr-name = displayName
+ home-dir-attr-name = homeDirectory
+ login-shell-attr-name = loginShell
+ group-member-attr-name = groupMembershipSAM
+ memberof-attr-name = memberOf
+ unix-password-attr-name = userPassword
 
 [nss_vas]
  group-update-mode = none

--- a/templates/vas.conf.erb
+++ b/templates/vas.conf.erb
@@ -105,6 +105,36 @@
 <% if @vas_conf_vasd_delusercheck_script != 'UNSET' -%>
  delusercheck-script = <%= @vas_conf_vasd_delusercheck_script %>
 <% end -%>
+<% if @vas_conf_vasd_username_attr_name != 'UNSET' -%>
+ username-attr-name = <%= @vas_conf_vasd_username_attr_name %>
+<% end -%>
+<% if @vas_conf_vasd_groupname_attr_name != 'UNSET' -%>
+ groupname-attr-name = <%= @vas_conf_vasd_groupname_attr_name %>
+<% end -%>
+<% if @vas_conf_vasd_uid_number_attr_name != 'UNSET' -%>
+ uid-number-attr-name = <%= @vas_conf_vasd_uid_number_attr_name %>
+<% end -%>
+<% if @vas_conf_vasd_gid_number_attr_name != 'UNSET' -%>
+ gid-number-attr-name = <%= @vas_conf_vasd_gid_number_attr_name %>
+<% end -%>
+<% if @vas_conf_vasd_gecos_attr_name != 'UNSET' -%>
+ gecos-attr-name = <%= @vas_conf_vasd_gecos_attr_name %>
+<% end -%>
+<% if @vas_conf_vasd_home_dir_attr_name != 'UNSET' -%>
+ home-dir-attr-name = <%= @vas_conf_vasd_home_dir_attr_name %>
+<% end -%>
+<% if @vas_conf_vasd_login_shell_attr_name != 'UNSET' -%>
+ login-shell-attr-name = <%= @vas_conf_vasd_login_shell_attr_name %>
+<% end -%>
+<% if @vas_conf_vasd_group_member_attr_name != 'UNSET' -%>
+ group-member-attr-name = <%= @vas_conf_vasd_group_member_attr_name %>
+<% end -%>
+<% if @vas_conf_vasd_memberof_attr_name != 'UNSET' -%>
+ memberof-attr-name = <%= @vas_conf_vasd_memberof_attr_name %>
+<% end -%>
+<% if @vas_conf_vasd_unix_password_attr_name != 'UNSET' -%>
+ unix-password-attr-name = <%= @vas_conf_vasd_unix_password_attr_name %>
+<% end -%>
 
 [nss_vas]
 <% if @vas_conf_group_update_mode != nil -%>


### PR DESCRIPTION
Hi, 
Added a number of parameters for vas.conf [vasd] 

> Schema customization for non-upm:
> username-attr-name = <string>
> groupname-attr-name = <string>
> uid-number-attr-name = <string>
> gid-number-attr-name = <string>
> gecos-attr-name = <string>
> home-dir-attr-name = <string>
> login-shell-attr-name = <string>
> group-member-attr-name = <string>
> memberof-attr-name = <string>
> unix-password-attr-name = <string>
