### PR TITLE
Added the parameter join_domain_controllers

### DIFF
--- a/README.md
+++ b/README.md
@@ -699,3 +699,9 @@ license_files
 Hash of license files
 
 - *Default*: undef
+
+join_domain_controllers
+-----------------------
+A string or an array with domain controllers to contact during the join process. Normally the servers for the domain will be automatically detected through DNS and LDAP lookups. By specifying this parameter vastool will contact the specified servers and only those servers during the join process. This can be useful if the machine being joined is not able to talk with all global Domain Controllers (e.g. due to firewalls). Note that this will have no effect after the join, where normal site discovery of servers will be made.
+
+- *Default*: 'UNSET'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -110,6 +110,7 @@ class vas (
   $symlink_vastool_binary                               = false,
   $license_files                                        = undef,
   $domain_realms                                        = {},
+  $join_domain_controllers                              = 'UNSET',
 ) {
 
   $domain_realms_real = merge({"${vas_fqdn}" => $realm}, $domain_realms)
@@ -331,6 +332,17 @@ class vas (
   } else {
     $enable_group_policies_real = $enable_group_policies
   }
+
+  if  is_array($join_domain_controllers) {
+    $join_domain_controllers_real = join($join_domain_controllers, ' ')
+  } else {
+    if $join_domain_controllers == 'UNSET' {
+      $join_domain_controllers_real = ''
+    } else {
+      $join_domain_controllers_real = $join_domain_controllers
+    }
+  }
+  validate_string($join_domain_controllers_real)
 
   case $::virtual {
     'zone': {
@@ -613,7 +625,7 @@ class vas (
   }
 
   exec { 'vasinst':
-    command => "${vastool_binary} -u ${username} -k ${keytab_path} -d3 join -f ${workstation_flag} -c ${computers_ou} ${user_search_path_parm} ${group_search_path_parm} ${upm_search_path_parm} -n ${vas_fqdn} ${s_opts} ${realm} > ${vasjoin_logfile} 2>&1 && touch ${once_file}",
+    command => "${vastool_binary} -u ${username} -k ${keytab_path} -d3 join -f ${workstation_flag} -c ${computers_ou} ${user_search_path_parm} ${group_search_path_parm} ${upm_search_path_parm} -n ${vas_fqdn} ${s_opts} ${realm} ${join_domain_controllers_real} > ${vasjoin_logfile} 2>&1 && touch ${once_file}",
     path    => '/sbin:/bin:/usr/bin:/opt/quest/bin',
     timeout => 1800,
     creates => $once_file,

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -522,17 +522,6 @@ describe 'vas' do
     end
 
     context 'with join_domain_controllers set to invalid value (non-array or string)' do
-      let :facts do
-        {
-          :kernel                    => 'Linux',
-          :osfamily                  => 'RedHat',
-          :lsbmajdistrelease         => '6',
-          :operatingsystemmajrelease => '6',
-          :fqdn                      => 'host.example.com',
-          :domain                    => 'example.com',
-          :vas_version               => '4.1.0.21518',
-        }
-      end
       let :params do
         { :join_domain_controllers => false }
       end
@@ -854,69 +843,33 @@ DOMAIN\\adgroup:group::
   end
 
   context 'with join_domain_controllers unset' do
-    let :facts do
-      {
-        :kernel                    => 'Linux',
-        :osfamily                  => 'RedHat',
-        :lsbmajdistrelease         => '6',
-        :operatingsystemmajrelease => '6',
-        :fqdn                      => 'host.example.com',
-        :domain                    => 'example.com',
-        :vas_version               => '4.1.0.21518',
-      }
-    end
     let :params do
       {
-        :realm           => 'example.com',
         :vasjoin_logfile => '/tmp/vasjoin.log'
       }
     end
 
-    it { should contain_exec('vasinst').with_command(/example\.com\s+>\s+\/tmp\/vasjoin.log/) }
+    it { should contain_exec('vasinst').with_command(/realm\.example\.com\s+>\s+\/tmp\/vasjoin.log/) }
   end
   context 'with join_domain_controllers as a string' do
-    let :facts do
-      {
-        :kernel                    => 'Linux',
-        :osfamily                  => 'RedHat',
-        :lsbmajdistrelease         => '6',
-        :operatingsystemmajrelease => '6',
-        :fqdn                      => 'host.example.com',
-        :domain                    => 'example.com',
-        :vas_version               => '4.1.0.21518',
-      }
-    end
     let :params do
       {
-        :realm           => 'example.com',
         :vasjoin_logfile => '/tmp/vasjoin.log',
         :join_domain_controllers => 'dc01.example.com'
       }
     end
 
-    it { should contain_exec('vasinst').with_command(/example\.com\s+dc01.example.com\s+>\s+\/tmp\/vasjoin.log/) }
+    it { should contain_exec('vasinst').with_command(/realm\.example\.com\s+dc01.example.com\s+>\s+\/tmp\/vasjoin.log/) }
   end
   context 'with join_domain_controllers as an array' do
-    let :facts do
-      {
-        :kernel                    => 'Linux',
-        :osfamily                  => 'RedHat',
-        :lsbmajdistrelease         => '6',
-        :operatingsystemmajrelease => '6',
-        :fqdn                      => 'host.example.com',
-        :domain                    => 'example.com',
-        :vas_version               => '4.1.0.21518',
-      }
-    end
     let :params do
       {
-        :realm           => 'example.com',
         :vasjoin_logfile => '/tmp/vasjoin.log',
         :join_domain_controllers => ['dc01.example.com', 'dc02.example.com']
       }
     end
 
-    it { should contain_exec('vasinst').with_command(/example\.com\s+dc01.example.com dc02.example.com\s+>\s+\/tmp\/vasjoin.log/) }
+    it { should contain_exec('vasinst').with_command(/realm\.example\.com\s+dc01.example.com dc02.example.com\s+>\s+\/tmp\/vasjoin.log/) }
   end
 
   hiera_merge_parameters = {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -521,6 +521,27 @@ describe 'vas' do
       end
     end
 
+    context 'with join_domain_controllers set to invalid value (non-array or string)' do
+      let :facts do
+        {
+          :kernel                    => 'Linux',
+          :osfamily                  => 'RedHat',
+          :lsbmajdistrelease         => '6',
+          :operatingsystemmajrelease => '6',
+          :fqdn                      => 'host.example.com',
+          :domain                    => 'example.com',
+          :vas_version               => '4.1.0.21518',
+        }
+      end
+      let :params do
+        { :join_domain_controllers => false }
+      end
+
+      it 'should fail' do
+        expect { should contain_class('vas') }.to raise_error(Puppet::Error, /is not a string/)
+      end
+    end
+
     context 'with users_allow_entries specified as an array on osfamily redhat with lsbmajdistrelease 6' do
       let :params do
         {
@@ -830,6 +851,72 @@ DOMAIN\\adgroup:group::
     it { should contain_exec('vasinst').with_command(/-c OU=Computers,DC=example,DC=com/) }
     it { should contain_exec('vasinst').with_command(/-n host.example.com/) }
     it { should_not contain_exec('vasinst').with_command(/-g/) }
+  end
+
+  context 'with join_domain_controllers unset' do
+    let :facts do
+      {
+        :kernel                    => 'Linux',
+        :osfamily                  => 'RedHat',
+        :lsbmajdistrelease         => '6',
+        :operatingsystemmajrelease => '6',
+        :fqdn                      => 'host.example.com',
+        :domain                    => 'example.com',
+        :vas_version               => '4.1.0.21518',
+      }
+    end
+    let :params do
+      {
+        :realm           => 'example.com',
+        :vasjoin_logfile => '/tmp/vasjoin.log'
+      }
+    end
+
+    it { should contain_exec('vasinst').with_command(/example\.com\s+>\s+\/tmp\/vasjoin.log/) }
+  end
+  context 'with join_domain_controllers as a string' do
+    let :facts do
+      {
+        :kernel                    => 'Linux',
+        :osfamily                  => 'RedHat',
+        :lsbmajdistrelease         => '6',
+        :operatingsystemmajrelease => '6',
+        :fqdn                      => 'host.example.com',
+        :domain                    => 'example.com',
+        :vas_version               => '4.1.0.21518',
+      }
+    end
+    let :params do
+      {
+        :realm           => 'example.com',
+        :vasjoin_logfile => '/tmp/vasjoin.log',
+        :join_domain_controllers => 'dc01.example.com'
+      }
+    end
+
+    it { should contain_exec('vasinst').with_command(/example\.com\s+dc01.example.com\s+>\s+\/tmp\/vasjoin.log/) }
+  end
+  context 'with join_domain_controllers as an array' do
+    let :facts do
+      {
+        :kernel                    => 'Linux',
+        :osfamily                  => 'RedHat',
+        :lsbmajdistrelease         => '6',
+        :operatingsystemmajrelease => '6',
+        :fqdn                      => 'host.example.com',
+        :domain                    => 'example.com',
+        :vas_version               => '4.1.0.21518',
+      }
+    end
+    let :params do
+      {
+        :realm           => 'example.com',
+        :vasjoin_logfile => '/tmp/vasjoin.log',
+        :join_domain_controllers => ['dc01.example.com', 'dc02.example.com']
+      }
+    end
+
+    it { should contain_exec('vasinst').with_command(/example\.com\s+dc01.example.com dc02.example.com\s+>\s+\/tmp\/vasjoin.log/) }
   end
 
   hiera_merge_parameters = {


### PR DESCRIPTION
A string or an array with domain controllers to contact during the join
process. Normally the servers for the domain will be automatically
detected through DNS and LDAP lookups. By specifying this parameter
vastool will contact the specified servers and only those servers during
the join process. This can be useful if the machine being joined is not
able to talk with all global Domain Controllers (e.g. due to firewalls).
Note that this will have no effect after the join, where normal site
discovery of servers will be made.