### PR TITLE
Enable configurable expand-ac-groups in vas.conf

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -7,6 +7,6 @@ fixtures:
     'rpcbind': 'git://github.com/ghoneycutt/puppet-module-rpcbind.git'
     'stdlib':
       repo: 'git://github.com/puppetlabs/puppetlabs-stdlib.git'
-      ref: '4.6.0'
+      ref: '4.10.0'
   symlinks:
     vas: "#{source_dir}"

--- a/Gemfile
+++ b/Gemfile
@@ -19,3 +19,5 @@ if RUBY_VERSION >= '1.8.7' and RUBY_VERSION < '1.9'
   # rake must be v10 for ruby 1.8.7
   gem 'rake', '~> 10.0'
 end
+
+gem 'json', '~> 1.0' if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '2.0'

--- a/README.md
+++ b/README.md
@@ -466,6 +466,12 @@ Stringified boolean to be used for allow-disconnected-auth option in [vas_auth] 
 
 - *Default*: 'UNSET'
 
+vas_conf_vas_auth_expand_ac_groups
+-----------------------------------------
+Stringified boolean to be used for expand-ac-groups option in [vas_auth] section of vas.conf. See VAS.CONF(5) for more info.
+
+- *Default*: 'UNSET'
+
 vas_conf_libvas_vascache_ipc_timeout
 ------------------------------------
 Integer for number of seconds to set value of vascache-ipc-timeout in [libvas] section of vas.conf. See VAS.CONF(5) for more info.

--- a/README.md
+++ b/README.md
@@ -462,13 +462,15 @@ Integer for uid-check-limit option in vas.conf. See VAS.CONF(5) for more info.
 
 vas_conf_vas_auth_allow_disconnected_auth
 -----------------------------------------
-Stringified boolean to be used for allow-disconnected-auth option in [vas_auth] section of vas.conf. See VAS.CONF(5) for more info.
+Boolean to set value of allow-disconnected-auth option in [vas_auth] section of vas.conf. See VAS.CONF(5) for more info.
+If set to 'UNSET' nothing will get printed.
 
 - *Default*: 'UNSET'
 
 vas_conf_vas_auth_expand_ac_groups
 -----------------------------------------
-Stringified boolean to be used for expand-ac-groups option in [vas_auth] section of vas.conf. See VAS.CONF(5) for more info.
+Boolean to set value of expand-ac-groups option in [vas_auth] section of vas.conf. See VAS.CONF(5) for more info.
+If set to 'UNSET' nothing will get printed.
 
 - *Default*: 'UNSET'
 

--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,7 @@ require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-lint/tasks/puppet-lint'
 
 PuppetLint.configuration.send('disable_80chars')
+PuppetLint.configuration.send('disable_140chars')
 PuppetLint.configuration.ignore_paths = ['spec/**/*.pp', 'pkg/**/*.pp']
 
 desc 'Run puppet in noop mode and check for syntax errors.'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -165,9 +165,18 @@ class vas (
   }
 
   if $vas_conf_vas_auth_expand_ac_groups != 'UNSET' {
-    validate_re($vas_conf_vas_auth_expand_ac_groups, '^(true|false)$',
-      'vas_conf_vas_auth_expand_ac_groups does not match regex. Valid values are <true> and <false>.'
-    )
+    if type3x($vas_conf_vas_auth_expand_ac_groups) == 'boolean' {
+      $vas_conf_vas_auth_expand_ac_groups_string = bool2str($vas_conf_vas_auth_expand_ac_groups)
+    }
+    elsif type3x($vas_conf_vas_auth_expand_ac_groups) == 'string' {
+      validate_re($vas_conf_vas_auth_expand_ac_groups, '^(true|false)$',
+        'vas_conf_vas_auth_expand_ac_groups is not a boolean. Valid values are <true> and <false>.'
+      )
+      $vas_conf_vas_auth_expand_ac_groups_string = $vas_conf_vas_auth_expand_ac_groups
+    }
+    else {
+      fail('vas_conf_vas_auth_expand_ac_groups is not a boolean nor a string. Valid values are <true> and <false>.')
+    }
   }
 
   if is_string($domain_change) {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -69,6 +69,7 @@ class vas (
   $vas_conf_libdefaults_forwardable                     = true,
   $vas_conf_vas_auth_uid_check_limit                    = 'UNSET',
   $vas_conf_vas_auth_allow_disconnected_auth            = 'UNSET',
+  $vas_conf_vas_auth_expand_ac_groups                   = 'UNSET',
   $vas_conf_libvas_vascache_ipc_timeout                 = 15,
   $vas_conf_libvas_use_server_referrals                 = true,
   $vas_conf_libvas_use_server_referrals_version_switch  = '4.1.0.21518',
@@ -160,6 +161,12 @@ class vas (
   if $vas_conf_vas_auth_allow_disconnected_auth != 'UNSET' {
     validate_re($vas_conf_vas_auth_allow_disconnected_auth, '^(true|false)$',
       'vas_conf_vas_auth_allow_disconnected_auth does not match regex. Valid values are <true> and <false>.'
+    )
+  }
+
+  if $vas_conf_vas_auth_expand_ac_groups != 'UNSET' {
+    validate_re($vas_conf_vas_auth_expand_ac_groups, '^(true|false)$',
+      'vas_conf_vas_auth_expand_ac_groups does not match regex. Valid values are <true> and <false>.'
     )
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -159,9 +159,18 @@ class vas (
   validate_string($vas_conf_vasd_unix_password_attr_name)
 
   if $vas_conf_vas_auth_allow_disconnected_auth != 'UNSET' {
-    validate_re($vas_conf_vas_auth_allow_disconnected_auth, '^(true|false)$',
-      'vas_conf_vas_auth_allow_disconnected_auth does not match regex. Valid values are <true> and <false>.'
-    )
+    if type3x($vas_conf_vas_auth_allow_disconnected_auth) == 'boolean' {
+      $vas_conf_vas_auth_allow_disconnected_auth_string = bool2str($vas_conf_vas_auth_allow_disconnected_auth)
+    }
+    elsif type3x($vas_conf_vas_auth_allow_disconnected_auth) == 'string' {
+      validate_re($vas_conf_vas_auth_allow_disconnected_auth, '^(true|false)$',
+        'vas_conf_vas_auth_allow_disconnected_auth is not a boolean. Valid values are <true> and <false>.'
+      )
+      $vas_conf_vas_auth_allow_disconnected_auth_string = $vas_conf_vas_auth_allow_disconnected_auth
+    }
+    else {
+      fail('vas_conf_vas_auth_allow_disconnected_auth is not a boolean nor a string. Valid values are <true> and <false>.')
+    }
   }
 
   if $vas_conf_vas_auth_expand_ac_groups != 'UNSET' {

--- a/metadata.json
+++ b/metadata.json
@@ -84,6 +84,6 @@
     { "version_requirement": ">= 0.1.0", "name": "ericsson/nisclient" },
     { "version_requirement": ">= 2.0.0", "name": "ghoneycutt/pam" },
     { "version_requirement": ">= 1.0.0", "name": "ghoneycutt/nsswitch" },
-    { "version_requirement": ">= 4.2.0", "name": "puppetlabs/stdlib" }
+    { "version_requirement": ">= 4.10.0", "name": "puppetlabs/stdlib" }
   ]
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -240,8 +240,8 @@ describe 'vas' do
           :vas_conf_vasd_lazy_cache_update_interval             => '5',
           :vas_conf_vasd_password_change_script_timelimit       => '30',
           :vas_conf_libvas_auth_helper_timeout                  => '120',
-          :vas_conf_vas_auth_allow_disconnected_auth            => 'false',
-          :vas_conf_vas_auth_expand_ac_groups                   => 'false',
+          :vas_conf_vas_auth_allow_disconnected_auth            => false,
+          :vas_conf_vas_auth_expand_ac_groups                   => false,
           :sitenameoverride                                     => 'foobar',
           :vas_conf_libvas_use_dns_srv                          => 'false',
           :vas_conf_libvas_use_tcp_only                         => 'false',
@@ -1085,16 +1085,10 @@ DOMAIN\\adgroup:group::
 
     validations = {
       'boolean' => {
-        :name    => %w(user_override_hiera_merge group_override_hiera_merge domain_change unjoin_vas vas_conf_vas_auth_expand_ac_groups),
+        :name    => %w(user_override_hiera_merge group_override_hiera_merge domain_change unjoin_vas vas_conf_vas_auth_allow_disconnected_auth vas_conf_vas_auth_expand_ac_groups),
         :valid   => [true, false, 'true', 'false'],
         :invalid => ['string', ['array'], { 'ha' => 'sh' }, 3, 2.42, nil],
         :message => '(is not a boolean|Unknown type of boolean)',
-      },
-      'stringified_boolean' => {
-        :name    => %w(vas_conf_vas_auth_allow_disconnected_auth),
-        :valid   => ['true', 'false' ],
-        :invalid => [%w(array), { 'ha' => 'sh' }, 3, 2.42, true, false, nil ],
-        :message => 'Valid values are <true> and <false>',
       },
     }
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1085,19 +1085,13 @@ DOMAIN\\adgroup:group::
 
     validations = {
       'boolean' => {
-        :name    => %w(user_override_hiera_merge group_override_hiera_merge domain_change unjoin_vas),
+        :name    => %w(user_override_hiera_merge group_override_hiera_merge domain_change unjoin_vas vas_conf_vas_auth_expand_ac_groups),
         :valid   => [true, false, 'true', 'false'],
         :invalid => ['string', ['array'], { 'ha' => 'sh' }, 3, 2.42, nil],
         :message => '(is not a boolean|Unknown type of boolean)',
       },
       'stringified_boolean' => {
         :name    => %w(vas_conf_vas_auth_allow_disconnected_auth),
-        :valid   => ['true', 'false' ],
-        :invalid => [%w(array), { 'ha' => 'sh' }, 3, 2.42, true, false, nil ],
-        :message => 'Valid values are <true> and <false>',
-      },
-      'stringified_boolean' => {
-        :name    => %w(vas_conf_vas_auth_expand_ac_groups),
         :valid   => ['true', 'false' ],
         :invalid => [%w(array), { 'ha' => 'sh' }, 3, 2.42, true, false, nil ],
         :message => 'Valid values are <true> and <false>',

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -241,6 +241,7 @@ describe 'vas' do
           :vas_conf_vasd_password_change_script_timelimit       => '30',
           :vas_conf_libvas_auth_helper_timeout                  => '120',
           :vas_conf_vas_auth_allow_disconnected_auth            => 'false',
+          :vas_conf_vas_auth_expand_ac_groups                   => 'false',
           :sitenameoverride                                     => 'foobar',
           :vas_conf_libvas_use_dns_srv                          => 'false',
           :vas_conf_libvas_use_tcp_only                         => 'false',
@@ -340,6 +341,7 @@ describe 'vas' do
 [vas_auth]
  uid-check-limit = 100000
  allow-disconnected-auth = false
+ expand-ac-groups = false
 ))
       end
     end
@@ -1090,6 +1092,12 @@ DOMAIN\\adgroup:group::
       },
       'stringified_boolean' => {
         :name    => %w(vas_conf_vas_auth_allow_disconnected_auth),
+        :valid   => ['true', 'false' ],
+        :invalid => [%w(array), { 'ha' => 'sh' }, 3, 2.42, true, false, nil ],
+        :message => 'Valid values are <true> and <false>',
+      },
+      'stringified_boolean' => {
+        :name    => %w(vas_conf_vas_auth_expand_ac_groups),
         :valid   => ['true', 'false' ],
         :invalid => [%w(array), { 'ha' => 'sh' }, 3, 2.42, true, false, nil ],
         :message => 'Valid values are <true> and <false>',

--- a/templates/vas.conf.erb
+++ b/templates/vas.conf.erb
@@ -163,8 +163,8 @@
 <% if @vas_conf_vas_auth_uid_check_limit != 'UNSET' -%>
  uid-check-limit = <%= @vas_conf_vas_auth_uid_check_limit %>
 <% end -%>
-<% if @vas_conf_vas_auth_allow_disconnected_auth != 'UNSET' -%>
- allow-disconnected-auth = <%= @vas_conf_vas_auth_allow_disconnected_auth %>
+<% if @vas_conf_vas_auth_allow_disconnected_auth_string != nil -%>
+ allow-disconnected-auth = <%= @vas_conf_vas_auth_allow_disconnected_auth_string %>
 <% end -%>
 <% if @vas_conf_vas_auth_expand_ac_groups_string != nil -%>
  expand-ac-groups = <%= @vas_conf_vas_auth_expand_ac_groups_string %>

--- a/templates/vas.conf.erb
+++ b/templates/vas.conf.erb
@@ -166,6 +166,6 @@
 <% if @vas_conf_vas_auth_allow_disconnected_auth != 'UNSET' -%>
  allow-disconnected-auth = <%= @vas_conf_vas_auth_allow_disconnected_auth %>
 <% end -%>
-<% if @vas_conf_vas_auth_expand_ac_groups != 'UNSET' -%>
- expand-ac-groups = <%= @vas_conf_vas_auth_expand_ac_groups %>
+<% if @vas_conf_vas_auth_expand_ac_groups_string != nil -%>
+ expand-ac-groups = <%= @vas_conf_vas_auth_expand_ac_groups_string %>
 <% end -%>

--- a/templates/vas.conf.erb
+++ b/templates/vas.conf.erb
@@ -166,3 +166,6 @@
 <% if @vas_conf_vas_auth_allow_disconnected_auth != 'UNSET' -%>
  allow-disconnected-auth = <%= @vas_conf_vas_auth_allow_disconnected_auth %>
 <% end -%>
+<% if @vas_conf_vas_auth_expand_ac_groups != 'UNSET' -%>
+ expand-ac-groups = <%= @vas_conf_vas_auth_expand_ac_groups %>
+<% end -%>


### PR DESCRIPTION
continued work on https://github.com/Ericsson/puppet-module-vas/pull/99 from @boandersson 

Real booleans should also be supported. bool2str() from stdlib 4.10.0 does the trick.
stdlib 4.10.0 did change the behaviour of validate_re(), it now fails on wrong data types.

Needed rework on $vas_conf_vas_auth_allow_disconnected_auth which now also support real booleans :)