### PR TITLE
Puppet4 bugfix

### DIFF
--- a/lib/facter/vas_domain.rb
+++ b/lib/facter/vas_domain.rb
@@ -6,7 +6,9 @@ Facter.add('vas_domain') do
     if Facter::Util::Resolution.exec(test_installed) == '0'
       cmd = '/opt/quest/bin/vastool info domain 2>/dev/null'
       response = Facter::Util::Resolution.exec(cmd)
-      response
+      if !response.to_s.empty?
+        response
+      end
     end
   end
 end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -528,7 +528,7 @@ class vas (
       # it will join the domain with help of the lastjoin file.
       # If the domain_change_real fact is false, it will fail the compilation and warn
       # of the mismatching realm.
-      if $::vas_domain != $realm and $::vas_domain != undef  {
+      if $::vas_domain != $realm and $::vas_domain != undef {
         if $domain_change_real == true {
           exec { 'vas_change_domain':
             # This command executes the result of the sed command, puts the log from
@@ -556,7 +556,7 @@ class vas (
             require  => [Package['vasclnt','vasyp','vasgp']],
           }
         } else {
-          fail('VAS domain mismatch!')
+          fail("VAS domain mismatch, got <$vas_domain> but wanted <$realm>")
         }
       }
     }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -810,7 +810,7 @@ describe 'vas' do
         }
       end
       it 'should fail' do
-        expect { should contain_class('vas') }.to raise_error(Puppet::Error, /VAS domain mismatch!/)
+        expect { should contain_class('vas') }.to raise_error(Puppet::Error, /VAS domain mismatch/)
       end
     end
 


### PR DESCRIPTION
Ran into this bug in a new environment where we don't yet have a custom repo (i.e. we installed QAS packages manually before running puppet.)

Feel free to suggest better ways to check if vas_domain is empty or unset.