### PR TITLE
Netgroup conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,14 @@ Path for script to set value of delusercheck-script in [vasd] section of vas.con
 
 - *Default*: 'UNSET'
 
+vas_conf_vasd_netgroup_mode
+---------------------------
+String to be used to set value of netgroup-mode in the [vasd] section of vas.conf.
+Valid values are 'NSS', 'NIS' and 'OFF'. If not specified, the netgroup-mode parameter
+will not be set in vas.conf. See VAS.CONF(5) for more info.
+
+- *Default*: 'UNSET'
+
 vas_conf_vasd_username_attr_name
 --------------------------------
 String to be used for username-attr-name  in [vasd] section of vas.conf. See VAS.CONF(5) for more info.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -65,6 +65,7 @@ class vas (
   $vas_conf_vasd_group_member_attr_name                 = 'UNSET',
   $vas_conf_vasd_memberof_attr_name                     = 'UNSET',
   $vas_conf_vasd_unix_password_attr_name                = 'UNSET',
+  $vas_conf_vasd_netgroup_mode                          = 'UNSET',
   $vas_conf_prompt_vas_ad_pw                            = '"Enter Windows password: "',
   $vas_conf_pam_vas_prompt_ad_lockout_msg               = 'UNSET',
   $vas_conf_libdefaults_forwardable                     = true,
@@ -162,6 +163,12 @@ class vas (
   validate_string($vas_conf_vasd_group_member_attr_name)
   validate_string($vas_conf_vasd_memberof_attr_name)
   validate_string($vas_conf_vasd_unix_password_attr_name)
+  validate_string($vas_conf_vasd_netgroup_mode)
+
+  if $vas_conf_vasd_netgroup_mode != 'UNSET' {
+    validate_re($vas_conf_vasd_netgroup_mode, '^(NSS|NIS|OFF)$',
+      'Invalid value specified for vas_conf_vasd_netgroup_mode. Valid values are NSS, NIS and OFF')
+  }
 
   if $vas_conf_vas_auth_allow_disconnected_auth != 'UNSET' {
     if type3x($vas_conf_vas_auth_allow_disconnected_auth) == 'boolean' {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -228,6 +228,7 @@ describe 'vas' do
           :vas_conf_vasd_group_member_attr_name                 => 'groupMembershipSAM',
           :vas_conf_vasd_memberof_attr_name                     => 'memberOf',
           :vas_conf_vasd_unix_password_attr_name                => 'userPassword',
+          :vas_conf_vasd_netgroup_mode                          => 'NIS',
           :vas_conf_vasd_ws_resolve_uid                         => 'true',
           :vas_conf_vasd_lazy_cache_update_interval             => '5',
           :vas_conf_vasd_password_change_script_timelimit       => '30',
@@ -303,6 +304,7 @@ describe 'vas' do
         | upm-computerou-attr = managedBy
         | password-change-script = /opt/quest/libexec/vas-set-samba-password
         | password-change-script-timelimit = 30
+        | netgroup-mode = NIS
         | username-attr-name = userprincipalname
         | groupname-attr-name = groupprincipalname
         | uid-number-attr-name = employeID
@@ -348,6 +350,16 @@ describe 'vas' do
       it do
         should contain_file('vas_config').with_content(/update-interval = 234577/)
       end
+    end
+
+    context 'with vas_conf_vasd_netgroup_mode set to valid string NSS' do
+      let(:params) { { :vas_conf_vasd_netgroup_mode => 'NSS', } }
+      it { should contain_file('vas_config').with_content(/^[ ]*netgroup-mode = NSS$/) }
+    end
+
+    context 'with vas_conf_vasd_netgroup_mode set to valid string UNSET' do
+      let(:params) { { :vas_conf_vasd_netgroup_mode => 'UNSET', } }
+      it { should contain_file('vas_config').without_content(/^[ ]*netgroup-mode/) }
     end
 
     context 'with use_server_referrals enabled by vas version' do
@@ -1119,6 +1131,12 @@ describe 'vas' do
     end
 
     validations = {
+      'netgroup_mode' => {
+        :name    => %w(vas_conf_vasd_netgroup_mode),
+        :valid   => ['UNSET', 'NSS', 'NIS', 'OFF'],
+        :invalid => [{ 'ha' => 'sh' }, 3, 2.42, true, false, 'nss', 'nis', 'off'],
+        :message => 'Valid values are NSS, NIS and OFF|is not a string'
+      },
       'array/string' => {
         :name    => %w(join_domain_controllers),
         :valid   => [%w(array), 'string'],

--- a/templates/vas.conf.erb
+++ b/templates/vas.conf.erb
@@ -105,6 +105,9 @@
 <% if @vas_conf_vasd_delusercheck_script != 'UNSET' -%>
  delusercheck-script = <%= @vas_conf_vasd_delusercheck_script %>
 <% end -%>
+<% if @vas_conf_vasd_netgroup_mode != 'UNSET' -%>
+ netgroup-mode = <%= @vas_conf_vasd_netgroup_mode %>
+<% end -%>
 <% if @vas_conf_vasd_username_attr_name != 'UNSET' -%>
  username-attr-name = <%= @vas_conf_vasd_username_attr_name %>
 <% end -%>


### PR DESCRIPTION
Add configurable parameter for netgroup-mode in vas.conf. Specifically required for turning off vasd netgroup handling for a site that doesn't use netgroups (join fails unless turning it off.)
Code tested in our environment.