### PR TITLE
upm-computerou-attr should be unset by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,9 +272,9 @@ update-process option in vas.conf. See VAS.CONF(5) for more info.
 
 vas_conf_upm_computerou_attr
 ----------------------------
-upm-computerou-attr option in vas.conf. Changed to 'department' to work in a multi-AD-domain setup. See VAS.CONF(5) for more info.
+upm-computerou-attr option in vas.conf. See VAS.CONF(5) for more info.
 
-- *Default*: 'department'
+- *Default*: 'UNSET'
 
 vas_conf_full_update_interval
 -----------------------------

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,7 +38,7 @@ class vas (
   $vas_conf_locked_out_pwhash                           = undef,
   $vas_conf_preload_nested_memberships                  = 'UNSET',
   $vas_conf_update_process                              = '/opt/quest/libexec/vas/mapupdate_2307',
-  $vas_conf_upm_computerou_attr                         = 'department',
+  $vas_conf_upm_computerou_attr                         = 'UNSET',
   $vas_conf_vasd_update_interval                        = '600',
   $vas_conf_vasd_auto_ticket_renew_interval             = '32400',
   $vas_conf_vasd_lazy_cache_update_interval             = '10',

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -119,7 +119,6 @@ describe 'vas' do
         | workstation-mode = false
         | auto-ticket-renew-interval = 32400
         | lazy-cache-update-interval = 10
-        | upm-computerou-attr = department
         |
         |[nss_vas]
         | group-update-mode = none

--- a/templates/vas.conf.erb
+++ b/templates/vas.conf.erb
@@ -87,7 +87,7 @@
 <% if @vas_conf_preload_nested_memberships != 'UNSET' -%>
  preload-nested-memberships = <%= @vas_conf_preload_nested_memberships %>
 <% end -%>
-<% if !@vas_conf_upm_computerou_attr.empty?-%>
+<% if @vas_conf_upm_computerou_attr != 'UNSET' -%>
  upm-computerou-attr = <%= @vas_conf_upm_computerou_attr %>
 <% end -%>
 <% if @vas_conf_vasd_password_change_script != 'UNSET' -%>


### PR DESCRIPTION
This attribute is set to department today but it should be undefined by default.