### PR TITLE
Realms  functionality 

### DIFF
--- a/README.md
+++ b/README.md
@@ -786,7 +786,7 @@ If set has the same effect as  issuing "vastool configure realm ericsson.se eris
 kpasswd_servers
 ----
 An array of kpasswd servers  that are to be entered under the [realms] section
-If set has the same effect as  issuing "vastool configure realm ericsson.se erisero01.ericsson.se erisero02.ericsson.se". (example)
+Normally needs not be set unless you want something different than the value of kdcs (above).
 - *Default*: ['UNSET']
 
 kdc_port

--- a/README.md
+++ b/README.md
@@ -777,4 +777,20 @@ A bool to achieve the same thing as issuing "vastool configure vas libvas use-sr
 Only has any effect if set to false.
 
 - *Default*: 'UNSET'
+kdcs
+----
+An array of kdcs that are to be entered under the [realms] section
+If set has the same effect as  issuing "vastool configure realm ericsson.se erisero01.ericsson.se erisero02.ericsson.se". (example)
+- *Default*: ['UNSET']
 
+kdc_port
+--------
+A string containing the kdc port. 
+Has no effect unless kdcs is populated with servernames.
+- *Default*: '88'
+
+kpasswd_server_port
+-------------------
+A string containing the kpasswd server port. 
+Has no effect unless kdcs is populated with servernames.
+- *Default*: '464'

--- a/README.md
+++ b/README.md
@@ -783,6 +783,12 @@ An array of kdcs that are to be entered under the [realms] section
 If set has the same effect as  issuing "vastool configure realm ericsson.se erisero01.ericsson.se erisero02.ericsson.se". (example)
 - *Default*: ['UNSET']
 
+kpasswd_servers
+----
+An array of kpasswd servers  that are to be entered under the [realms] section
+If set has the same effect as  issuing "vastool configure realm ericsson.se erisero01.ericsson.se erisero02.ericsson.se". (example)
+- *Default*: ['UNSET']
+
 kdc_port
 --------
 A string containing the kdc port. 

--- a/README.md
+++ b/README.md
@@ -770,3 +770,11 @@ join_domain_controllers
 A string or an array with domain controllers to contact during the join process. Normally the servers for the domain will be automatically detected through DNS and LDAP lookups. By specifying this parameter vastool will contact the specified servers and only those servers during the join process. This can be useful if the machine being joined is not able to talk with all global Domain Controllers (e.g. due to firewalls). Note that this will have no effect after the join, where normal site discovery of servers will be made.
 
 - *Default*: 'UNSET'
+
+use_srv_infocache
+-----------------
+A bool to achieve the same thing as issuing "vastool configure vas libvas use-srv-info-cache <bool>"
+Only has any effect if set to false.
+
+- *Default*: 'UNSET'
+

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -122,7 +122,7 @@ class vas (
   $use_srv_infocache                                    = 'UNSET',
   $kdcs                                                 = ['UNSET'],
   $kdc_port                                             = '88',
-  $kpasswd_servers                                      = @kdcs,
+  $kpasswd_servers                                      = $kdcs,
   $kpasswd_server_port                                  = '464',
 ) {
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -409,7 +409,7 @@ class vas (
   if  $kdcs != ['UNSET'] and $kpasswd_servers != ['UNSET'] {
     $kdcs_real=$kdcs
     $kpasswd_servers_real = $kpasswd_servers
-  } else { 
+  } else {
     $kdcs_real=$kdcs
     $kpasswd_servers_real = $kdcs
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -398,7 +398,7 @@ class vas (
     validate_array($kdcs)
   }
 
-  if $kpasswd_servers != ['UNSET'] {
+  if $kpasswd_servers != $kdcs {
     validate_array($kpasswd_servers)
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -406,6 +406,14 @@ class vas (
 
   validate_string($kpasswd_server_port)
 
+  if  $kdcs != ['UNSET'] and $kpasswd_servers != ['UNSET'] {
+    $kdcs_real=$kdcs
+    $kpasswd_servers_real = $kpasswd_servers
+  } else { 
+    $kdcs_real=$kdcs
+    $kpasswd_servers_real = $kdcs
+  }
+
   case type3x($join_domain_controllers) {
     'array': { $join_domain_controllers_real = join($join_domain_controllers, ' ') }
     'string': {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -119,6 +119,7 @@ class vas (
   $domain_realms                                        = {},
   $join_domain_controllers                              = 'UNSET',
   $unjoin_vas                                           = false,
+  $use_srv_infocache                                      = 'UNSET',
 ) {
 
   $domain_realms_real = merge({"${vas_fqdn}" => $realm}, $domain_realms)
@@ -383,6 +384,10 @@ class vas (
     $enable_group_policies_real = str2bool($enable_group_policies)
   } else {
     $enable_group_policies_real = $enable_group_policies
+  }
+
+  if $use_srv_infocache != 'UNSET' {
+    validate_bool($use_srv_infocache)
   }
 
   case type3x($join_domain_controllers) {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -395,11 +395,10 @@ class vas (
   }
 
   if $kdcs != ['UNSET'] {
-    validate_array($kdcs) 
-    $kpasswd_servers=$kdcs
+    validate_array($kdcs)
   }
 
-  if $kpasswd_servers != ['UNSET'] and  $kpasswd_servers != $kdcs {
+  if $kpasswd_servers != ['UNSET'] {
     validate_array($kpasswd_servers)
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -395,10 +395,11 @@ class vas (
   }
 
   if $kdcs != ['UNSET'] {
-    validate_array($kdcs)
+    validate_array($kdcs) 
+    $kpasswd_servers=$kdcs
   }
 
-  if $kpasswd_servers != ['UNSET'] {
+  if $kpasswd_servers != ['UNSET'] and  $kpasswd_servers != $kdcs {
     validate_array($kpasswd_servers)
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -119,7 +119,11 @@ class vas (
   $domain_realms                                        = {},
   $join_domain_controllers                              = 'UNSET',
   $unjoin_vas                                           = false,
-  $use_srv_infocache                                      = 'UNSET',
+  $use_srv_infocache                                    = 'UNSET',
+  $kdcs                                                 = ['UNSET'],
+  $kdc_port                                             = '88',
+  $kpasswd_servers                                      = ['UNSET'],
+  $kpasswd_server_port                                  = '464',
 ) {
 
   $domain_realms_real = merge({"${vas_fqdn}" => $realm}, $domain_realms)
@@ -389,6 +393,18 @@ class vas (
   if $use_srv_infocache != 'UNSET' {
     validate_bool($use_srv_infocache)
   }
+
+  if $kdcs != ['UNSET'] {
+    validate_array($kdcs)
+  }
+
+  if $kpasswd_servers != ['UNSET'] {
+    validate_array($kpasswd_servers)
+  }
+
+  validate_string($kdc_port)
+
+  validate_string($kpasswd_server_port)
 
   case type3x($join_domain_controllers) {
     'array': { $join_domain_controllers_real = join($join_domain_controllers, ' ') }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -122,7 +122,7 @@ class vas (
   $use_srv_infocache                                    = 'UNSET',
   $kdcs                                                 = ['UNSET'],
   $kdc_port                                             = '88',
-  $kpasswd_servers                                      = $kdcs,
+  $kpasswd_servers                                      = ['UNSET'],
   $kpasswd_server_port                                  = '464',
 ) {
 
@@ -398,7 +398,7 @@ class vas (
     validate_array($kdcs)
   }
 
-  if $kpasswd_servers != $kdcs {
+  if $kpasswd_servers != ['UNSET'] {
     validate_array($kpasswd_servers)
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -122,7 +122,7 @@ class vas (
   $use_srv_infocache                                    = 'UNSET',
   $kdcs                                                 = ['UNSET'],
   $kdc_port                                             = '88',
-  $kpasswd_servers                                      = ['UNSET'],
+  $kpasswd_servers                                      = @kdcs,
   $kpasswd_server_port                                  = '464',
 ) {
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -125,6 +125,8 @@ describe 'vas' do
         | root-update-mode = none
         |
         |[vas_auth]
+	|
+	|[realms]
       END
 
       it do
@@ -331,6 +333,8 @@ describe 'vas' do
         | uid-check-limit = 100000
         | allow-disconnected-auth = false
         | expand-ac-groups = false
+	|
+	|[realms]
       END
 
       it do

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -125,6 +125,9 @@ describe 'vas' do
         | root-update-mode = none
         |
         |[vas_auth]
+	|uid-check-limit = 100000
+        |allow-disconnected-auth = false
+        |expand-ac-groups = false
 	|
 	|[realms]
       END

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -125,6 +125,8 @@ describe 'vas' do
         | root-update-mode = none
         |
         |[vas_auth]
+	|
+	|[realms]
       END
 
       it do

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -125,11 +125,6 @@ describe 'vas' do
         | root-update-mode = none
         |
         |[vas_auth]
-	|uid-check-limit = 100000
-        |allow-disconnected-auth = false
-        |expand-ac-groups = false
-	|
-	|[realms]
       END
 
       it do

--- a/templates/vas.conf.erb
+++ b/templates/vas.conf.erb
@@ -184,11 +184,11 @@
  <%= @realm.upcase -%> = {
 
  kdc = <% @kdcs.each do | kdc | -%>
- <%= @kdc:@kdc_port -%>
+ <%= @kdc -%>:<%= @kdc_port -%>
 
  <% end -%>
  kpasswd_server = <% @kpasswd_servers.each do | server | -%>
- <%= @server:@kpasswd_server_port -%>
+ <%= @server -%>:<%= @kpasswd_server_port -%>
   <% end -%>
 }
 <% end -%>

--- a/templates/vas.conf.erb
+++ b/templates/vas.conf.erb
@@ -182,13 +182,13 @@
 <% if @kdcs != ['UNSET'] && @kpasswd_servers!= ['UNSET'] -%>
 
  <%= @realm.upcase -%> = {
-
  kdc = <% @kdcs.each do | kdc | -%>
- <%= kdc %>:<%= @kdc_port %>
-
+ <%= kdc %>:<%= @kdc_port -%>
  <% end -%>
+
  kpasswd_server = <% @kpasswd_servers.each do | server | -%>
- <%= server %>:<%= @kpasswd_server_port %>
+ <%= server %>:<%= @kpasswd_server_port -%>
   <% end -%>
+
 }
 <% end -%>

--- a/templates/vas.conf.erb
+++ b/templates/vas.conf.erb
@@ -187,7 +187,7 @@
  kdc:<%= @kdc_port -%>
  <% end -%>
  passwd_server = <% @kdcs.each do | server | -%>
- <%= server:@kpasswd_server_port -%>
+ server:<%= @kpasswd_server_port -%>
   <% end -%>
 }
 <% end -%>

--- a/templates/vas.conf.erb
+++ b/templates/vas.conf.erb
@@ -177,3 +177,17 @@
 <% if @vas_conf_vas_auth_expand_ac_groups_string != nil -%>
  expand-ac-groups = <%= @vas_conf_vas_auth_expand_ac_groups_string %>
 <% end -%>
+
+[realms]
+<% if @kdcs != ['UNSET'] -%>
+
+ <%= @realm.upcase -%> = {
+
+ kdc = <% @kdcs.each do | kdc | -%>
+ <%= kdc:@kdc_port -%>
+ <% end -%>
+ passwd_server = <% @kdcs.each do | server | -%>
+ <%= server:@kpasswd_server_port -%>
+  <% end -%>
+}
+<% end -%>

--- a/templates/vas.conf.erb
+++ b/templates/vas.conf.erb
@@ -179,14 +179,14 @@
 <% end -%>
 
 [realms]
-<% if @kdcs != ['UNSET'] && @kpasswd_servers!= ['UNSET'] -%>
+<% if @kdcs_real != ['UNSET'] && @kpasswd_servers_real!= ['UNSET'] -%>
 
  <%= @realm.upcase -%> = {
- kdc = <% @kdcs.each do | kdc | -%>
+ kdc = <% @kdcs_real.each do | kdc | -%>
  <%= kdc %>:<%= @kdc_port -%>
  <% end -%>
 
- kpasswd_server = <% @kpasswd_servers.each do | server | -%>
+ kpasswd_server = <% @kpasswd_servers_real.each do | server | -%>
  <%= server %>:<%= @kpasswd_server_port -%>
   <% end -%>
 

--- a/templates/vas.conf.erb
+++ b/templates/vas.conf.erb
@@ -30,6 +30,9 @@
  use-tcp-only = <%= @vas_conf_libvas_use_tcp_only_real %>
  auth-helper-timeout = <%= @vas_conf_libvas_auth_helper_timeout %>
  site-only-servers = <%= @vas_conf_libvas_site_only_servers_real %>
+<% if @use_srv_infocache != 'UNSET' -%>
+ use-srvinfo-cache = <%= @use_srv_infocache %>
+<% end -%>
 
 [pam_vas]
  prompt-vas-ad-pw = <%= @vas_conf_prompt_vas_ad_pw %>

--- a/templates/vas.conf.erb
+++ b/templates/vas.conf.erb
@@ -184,10 +184,11 @@
  <%= @realm.upcase -%> = {
 
  kdc = <% @kdcs.each do | kdc | -%>
- kdc:<%= @kdc_port -%>
+ <%= @kdc:@kdc_port -%>
+
  <% end -%>
- passwd_server = <% @kpasswd_servers.each do | server | -%>
- server:<%= @kpasswd_server_port -%>
+ kpasswd_server = <% @kpasswd_servers.each do | server | -%>
+ <%= @server:@kpasswd_server_port -%>
   <% end -%>
 }
 <% end -%>

--- a/templates/vas.conf.erb
+++ b/templates/vas.conf.erb
@@ -184,7 +184,7 @@
  <%= @realm.upcase -%> = {
 
  kdc = <% @kdcs.each do | kdc | -%>
- <%= kdc:@kdc_port -%>
+ kdc:<%= @kdc_port -%>
  <% end -%>
  passwd_server = <% @kdcs.each do | server | -%>
  <%= server:@kpasswd_server_port -%>

--- a/templates/vas.conf.erb
+++ b/templates/vas.conf.erb
@@ -179,14 +179,14 @@
 <% end -%>
 
 [realms]
-<% if @kdcs != ['UNSET'] -%>
+<% if @kdcs != ['UNSET'] && @kpasswd_servers!= ['UNSET'] -%>
 
  <%= @realm.upcase -%> = {
 
  kdc = <% @kdcs.each do | kdc | -%>
  kdc:<%= @kdc_port -%>
  <% end -%>
- passwd_server = <% @kdcs.each do | server | -%>
+ passwd_server = <% @kpasswd_servers.each do | server | -%>
  server:<%= @kpasswd_server_port -%>
   <% end -%>
 }

--- a/templates/vas.conf.erb
+++ b/templates/vas.conf.erb
@@ -184,11 +184,11 @@
  <%= @realm.upcase -%> = {
 
  kdc = <% @kdcs.each do | kdc | -%>
- <%= @kdc -%>:<%= @kdc_port -%>
+ <%= kdc %>:<%= @kdc_port %>
 
  <% end -%>
  kpasswd_server = <% @kpasswd_servers.each do | server | -%>
- <%= @server -%>:<%= @kpasswd_server_port -%>
+ <%= server %>:<%= @kpasswd_server_port %>
   <% end -%>
 }
 <% end -%>


### PR DESCRIPTION
Adds a [realms] section and populates it with contents if kdcs and kpasswd_servers are defined.
It could be argued if they could be one and the same, which seems to be the case in real life.
Tested in SEKI and SERO and behaves as expected.
