### PR TITLE
Fix issue when fact vas_version is missing

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -609,9 +609,13 @@ class vas (
     default: { $gp_package_ensure = 'absent' }
   }
 
-  case versioncmp($facts['vas_version'], $vas_conf_libvas_use_server_referrals_version_switch) {
-    0, 1:    { $vas_conf_libvas_use_server_referrals_real = pick($vas_conf_libvas_use_server_referrals, false) } # equal (0) or greater (1)
-    default: { $vas_conf_libvas_use_server_referrals_real = pick($vas_conf_libvas_use_server_referrals, true) }  # smaller (-1)
+  if $facts['vas_version'] {
+    case versioncmp($facts['vas_version'], $vas_conf_libvas_use_server_referrals_version_switch) {
+      0, 1:    { $vas_conf_libvas_use_server_referrals_real = pick($vas_conf_libvas_use_server_referrals, false) } # equal (0) or greater (1)
+      default: { $vas_conf_libvas_use_server_referrals_real = pick($vas_conf_libvas_use_server_referrals, true) }  # smaller (-1)
+    }
+  } else {
+    $vas_conf_libvas_use_server_referrals_default = false
   }
 
   case $package_version {
@@ -619,7 +623,7 @@ class vas (
     default:     { $vasver = regsubst($package_version, '-', '.') }
   }
 
-  if $facts['vas_version'] =~ /^3/ and ($facts['vas_version'] !=undef or $vasver <= $facts['vas_version']) {
+  if $facts['vas_version'] and ($facts['vas_version'] =~ /^3/ and ($facts['vas_version'] !=undef or $vasver <= $facts['vas_version'])) {
     $_vas_is_v3 = true
   } else {
     $_vas_is_v3 = false

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -259,6 +259,17 @@ describe 'vas' do
         is_expected.not_to contain_file('vastool_symlink')
       }
 
+      describe 'with fact vas_version missing' do
+        vas_version_missing = { vas_version: nil }
+        let(:facts) do
+          os_facts.merge(
+            vas_version_missing,
+          )
+        end
+
+        it { is_expected.to compile }
+      end
+
       describe 'with users.{allow,deny} configured' do
         context 'with API enabled' do
           api_enabled = { 'api_enable': true }


### PR DESCRIPTION
Initial Puppet run with puppet-module-vas fails because versioncmp does not work with `Undef` variables.