### PR TITLE
Fix pdk validate github workflow

### DIFF
--- a/.github/workflows/run-pdk-validate.yml
+++ b/.github/workflows/run-pdk-validate.yml
@@ -14,4 +14,4 @@ jobs:
 
     - name: Run pdk validate
       # Modified puppets-epic-show-theatre with gcc and make installed
-      uses: kodguru/action-pdk-test-unit@buildtools
+      uses: kodguru/action-pdk-validate@buildtools


### PR DESCRIPTION
Oops. Didn't realise that there were different actions used for validate and test. Before this PR pdk test was executed instead of pdk validate for the validate action.

Made a fork of  puppets-epic-show-theatre/action-pdk-validate as well. Branch `buildtools` contains gcc and make to ensure gem `webmock` (or more precisely a dependency of) can be installed.