### PR TITLE
Setting GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/run-pdk-tests-on-puppet-7.yml
+++ b/.github/workflows/run-pdk-tests-on-puppet-7.yml
@@ -4,6 +4,8 @@ on:
   - push
   - pull_request
 
+permissions: read-all
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/run-pdk-tests-on-puppet-8.yml
+++ b/.github/workflows/run-pdk-tests-on-puppet-8.yml
@@ -4,6 +4,8 @@ on:
   - push
   - pull_request
 
+permissions: read-all
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/run-pdk-validate.yml
+++ b/.github/workflows/run-pdk-validate.yml
@@ -5,6 +5,8 @@ on:
   - push
   - pull_request
 
+permissions: read-all
+
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Set the permissions of the GITHUB_TOKEN of workflows to read-only to avoid misuse.

Addresses #159 