### PR TITLE
Pinning dependencies of GitHub actions

### DIFF
--- a/.github/workflows/run-pdk-tests-on-puppet-7.yml
+++ b/.github/workflows/run-pdk-tests-on-puppet-7.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Clone repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
     - name: Run unit tests
       # Modified puppets-epic-show-theatre with gcc and make installed

--- a/.github/workflows/run-pdk-tests-on-puppet-8.yml
+++ b/.github/workflows/run-pdk-tests-on-puppet-8.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Clone repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
     - name: Run unit tests
       # Modified puppets-epic-show-theatre with gcc and make installed

--- a/.github/workflows/run-pdk-validate.yml
+++ b/.github/workflows/run-pdk-validate.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Clone repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
     - name: Run pdk validate
       # Modified puppets-epic-show-theatre with gcc and make installed


### PR DESCRIPTION
This pins the dependencies of GitHub actions to the specific hash of the release commit. Version updates should then be driven through dependabot.

Adresses #159 