### PR TITLE
Add Github release configuration

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,0 +1,5 @@
+---
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release


### PR DESCRIPTION
Add Github release configuration to automatically exclude PRs with tag `exclude-changelog`.  This tag would also need to be excluded when running `github_changelog_generator` to generate CHANGELOG.md.

Should we use this tag och change it to something else? Github's documentation uses `ignore-for-release`. Maybe that is better.