### PR TITLE
Return hash instead of array from API function

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1225,7 +1225,7 @@ vas::api_fetch("https://host.domain.tld/api/${facts['trusted.certname']}")
 
 Query a remote HTTP-based service for entries to be added to users_allow.
 
-Returns: `Stdlib::Http::Status` If a valid response and contains entries
+Returns: `Hash` Key 'content' with [Array] if API responds. Key 'errors' with [Array[String]] if errors happens.
 
 ##### Examples
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -678,17 +678,16 @@ class vas (
   } elsif $api_enable == true {
     $api_users_allow_data = vas::api_fetch($api_users_allow_url, $api_token, $api_ssl_verify)
 
-    case $api_users_allow_data[0] {
-      200,'200': { # api_fetch() returns integer in Puppet 3 and string in Puppet 6
-        # VAS API is configured and responding
-        $manage_users_allow = true
-        $users_allow_entries_real = concat($users_allow_entries, $api_users_allow_data[1])
-      }
-      default: {
-        # VAS API is configured but down. Don't manage users_allow to prevent removal of entries.
-        $manage_users_allow = false
-        warning("VAS API Error. Code: ${api_users_allow_data[0]}, Error: ${api_users_allow_data[1]}")
-      }
+    if $api_users_allow_data['content'] {
+      $manage_users_allow = true
+      $users_allow_entries_real = concat($users_allow_entries, $api_users_allow_data['content'])
+    } else {
+      $manage_users_allow = false
+    }
+
+    if $api_users_allow_data['errors'] {
+      $api_errors = join($api_users_allow_data['errors'], ', ')
+      warning("API Error: ${api_errors}")
     }
   } else {
     $manage_users_allow = true

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -314,16 +314,17 @@ describe 'vas' do
               )
             end
 
-            context 'and returns 200' do
-              context 'without data' do
+            context 'and queries successfully' do
+              context 'with no return entries' do
                 let(:pre_condition) do
-                  'function vas::api_fetch($api_users_allow_url, $api_token, $api_ssl_verify) { return [200, undef] }'
+                  'function vas::api_fetch($api_users_allow_url, $api_token, $api_ssl_verify) {
+                    return { content => [] }
+                  }'
                 end
 
                 users_allow_api_nodata_content = <<-END.gsub(%r{^\s+\|}, '')
                   |# This file is being maintained by Puppet.
                   |# DO NOT EDIT
-                  |
                 END
 
                 it {
@@ -344,7 +345,6 @@ describe 'vas' do
                     |# DO NOT EDIT
                     |user1@example.com
                     |user2@example.com
-                    |
                   END
 
                   it {
@@ -353,9 +353,11 @@ describe 'vas' do
                 end
               end
 
-              context 'with data' do
+              context 'with it returning "apiuser@example.com"' do
                 let(:pre_condition) do
-                  'function vas::api_fetch($api_users_allow_url, $api_token, $api_ssl_verify) { return [200, \'apiuser@example.com\'] }'
+                  'function vas::api_fetch($api_users_allow_url, $api_token, $api_ssl_verify) {
+                    return { content => ["apiuser@example.com"]}
+                  }'
                 end
 
                 users_allow_api_data_content = <<-END.gsub(%r{^\s+\|}, '')
@@ -392,9 +394,11 @@ describe 'vas' do
               end
             end
 
-            context 'and return non-200 code' do
+            context 'and queries fails' do
               let(:pre_condition) do
-                'function vas::api_fetch($api_users_allow_url, $api_token, $api_ssl_verify) { return [0, undef] }'
+                'function vas::api_fetch($api_users_allow_url, $api_token, $api_ssl_verify) {
+                  return { error => ["https://host.domain.tld returns HTTP code: 502"] }
+                }'
               end
 
               it {

--- a/spec/classes/parameter_spec.rb
+++ b/spec/classes/parameter_spec.rb
@@ -918,11 +918,13 @@ describe 'vas' do
           }
         end
         let(:pre_condition) do
-          'function vas::api_fetch($api_users_allow_url, $api_token, $api_ssl_verify) { return [200, undef] }'
+          'function vas::api_fetch($api_users_allow_url, $api_token, $api_ssl_verify) {
+            return { content => [] }
+          }'
         end
 
         it do
-          is_expected.to contain_file('vas_users_allow').with_content(header + "\n")
+          is_expected.to contain_file('vas_users_allow').with_content(header)
         end
       end
 
@@ -935,7 +937,9 @@ describe 'vas' do
           }
         end
         let(:pre_condition) do
-          'function vas::api_fetch($api_users_allow_url, $api_token, $api_ssl_verify) { return [200, \'apiuser@test.ing\'] }'
+          'function vas::api_fetch($api_users_allow_url, $api_token, $api_ssl_verify) {
+            return { content => ["apiuser@test.ing"] }
+          }'
         end
 
         it do
@@ -953,11 +957,13 @@ describe 'vas' do
           }
         end
         let(:pre_condition) do
-          'function vas::api_fetch($api_users_allow_url, $api_token, $api_ssl_verify) { return [200, undef] }'
+          'function vas::api_fetch($api_users_allow_url, $api_token, $api_ssl_verify) {
+            return { content => [] }
+          }'
         end
 
         it do
-          is_expected.to contain_file('vas_users_allow').with_content(header + "user1@test.ing\nuser2@test.ing\n\n")
+          is_expected.to contain_file('vas_users_allow').with_content(header + "user1@test.ing\nuser2@test.ing\n")
         end
       end
 
@@ -971,7 +977,9 @@ describe 'vas' do
           }
         end
         let(:pre_condition) do
-          'function vas::api_fetch($api_users_allow_url, $api_token, $api_ssl_verify) { return [200, \'apiuser@test.ing\'] }'
+          'function vas::api_fetch($api_users_allow_url, $api_token, $api_ssl_verify) {
+            return { content => ["apiuser@test.ing"] }
+          }'
         end
 
         it do
@@ -1007,11 +1015,13 @@ describe 'vas' do
           }
         end
         let(:pre_condition) do
-          'function vas::api_fetch($api_users_allow_url, $api_token, $api_ssl_verify) { return [200, undef] }'
+          'function vas::api_fetch($api_users_allow_url, $api_token, $api_ssl_verify) {
+            return { content => [] }
+          }'
         end
 
         it do
-          is_expected.to contain_file('vas_users_allow').with_content(header + "\n")
+          is_expected.to contain_file('vas_users_allow').with_content(header)
         end
       end
 
@@ -1024,7 +1034,9 @@ describe 'vas' do
           }
         end
         let(:pre_condition) do
-          'function vas::api_fetch($api_users_allow_url, $api_token, $api_ssl_verify) { return [200, \'apiuser@test.ing\'] }'
+          'function vas::api_fetch($api_users_allow_url, $api_token, $api_ssl_verify) {
+            return { content => "apiuser@test.ing" }
+          }'
         end
 
         it do

--- a/spec/functions/api_fetch_spec.rb
+++ b/spec/functions/api_fetch_spec.rb
@@ -55,7 +55,7 @@ describe 'vas::api_fetch' do
 
       is_expected.to run
         .with_params(url, 'somesecret')
-        .and_return([0, 'execution expired'])
+        .and_return({ 'errors' => ['https://api.example.local/ connection failed: execution expired'] })
     end
 
     it 'returns an array containing http response code and body' do
@@ -63,12 +63,11 @@ describe 'vas::api_fetch' do
 
       stub_request(:get, url).with(
         headers: headers,
-      )
-                             .to_return(body: response_body, status: 200)
+      ).to_return(body: response_body, status: 200)
 
       is_expected.to run
         .with_params(url, 'somesecret')
-        .and_return(['200', ['line1', 'line2']])
+        .and_return({ 'content' => ['line1', 'line2'] })
     end
 
     it 'returns an array containing http response code and an empty array when response body is empty' do
@@ -76,34 +75,31 @@ describe 'vas::api_fetch' do
 
       stub_request(:get, url).with(
               headers: headers,
-            )
-                             .to_return(body: response_body, status: 200)
+            ).to_return(body: response_body, status: 200)
 
       is_expected.to run
         .with_params(url, 'somesecret')
-        .and_return(['200', []])
+        .and_return({ 'content' => [] })
     end
 
     it 'returns nil when http response code is not success' do
       stub_request(:get, url).with(
               headers: headers,
-            )
-                             .to_return(body: nil, status: 404)
+            ).to_return(body: nil, status: 404)
 
       is_expected.to run
         .with_params(url, 'somesecret')
-        .and_return(['404', nil])
+        .and_return({ 'errors' => ['https://api.example.local/ returns HTTP code: 404'] })
     end
 
     it 'returns an array containing 0 and error when error occurs' do
       stub_request(:get, url).with(
               headers: headers,
-            )
-                             .and_raise(StandardError.new('error'))
+            ).and_raise(StandardError.new('error'))
 
       is_expected.to run
         .with_params(url, 'somesecret')
-        .and_return([0, 'error'])
+        .and_return({ 'errors' => ['https://api.example.local/ connection failed: error'] })
     end
   end
 end


### PR DESCRIPTION
Initial step to add support to attempt API requests to multiple different URLs. API functions returns its data in a hash instead of array to allow easier parsing.